### PR TITLE
Use absolute_import, unicode_literals

### DIFF
--- a/stone/target/python_rsrc/stone_base.py
+++ b/stone/target/python_rsrc/stone_base.py
@@ -6,6 +6,8 @@ the future, this could be imported from a pre-installed Python package, rather
 than being added to a project.
 """
 
+from __future__ import absolute_import, unicode_literals
+
 try:
     from . import stone_validators as bv
 except (SystemError, ValueError):

--- a/stone/target/python_rsrc/stone_serializers.py
+++ b/stone/target/python_rsrc/stone_serializers.py
@@ -10,6 +10,8 @@ the future, this could be imported from a pre-installed Python package, rather
 than being added to a project.
 """
 
+from __future__ import absolute_import, unicode_literals
+
 import base64
 import collections
 import datetime

--- a/stone/target/python_rsrc/stone_validators.py
+++ b/stone/target/python_rsrc/stone_validators.py
@@ -10,6 +10,8 @@ the future, this could be imported from a pre-installed Python package, rather
 than being added to a project.
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from abc import ABCMeta, abstractmethod
 import datetime
 import math
@@ -60,7 +62,7 @@ class ValidationError(Exception):
 
     def __repr__(self):
         # Not a perfect repr, but includes the error location information.
-        return 'ValidationError(%r)' % str(self)
+        return 'ValidationError(%r)' % six.text_type(self)
 
 
 def generic_type_name(v):


### PR DESCRIPTION
Fixes type errors thrown when error messages have unicode characters.