### PR TITLE
Add some rudimentary PEP 484 (MyPy) annotations to the codebase.

### DIFF
--- a/mypy-run.sh
+++ b/mypy-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+mypy --strict-optional --silent-imports --fast-parser ./stone

--- a/mypy-run.sh
+++ b/mypy-run.sh
@@ -1,3 +1,8 @@
 #!/bin/bash -eux
 
-mypy --strict-optional --silent-imports --fast-parser ./stone
+EXCLUDE="(^example|ez_setup.py)"
+
+# Include all Python files registered in Git, that don't occur in $EXCLUDE.
+INCLUDE=$(git ls-files "$@" | grep '\.py$' | egrep -v "$EXCLUDE" | tr '\n' '\0' | xargs -0 | cat)
+
+mypy --strict-optional --silent-imports --fast-parser $INCLUDE

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,11 @@ except ImportError:
 
 from setuptools import setup
 
-install_reqs = ['ply>=3.4',
-                'six>=1.3.0']
+install_reqs = [
+    'ply>=3.4',
+    'six>=1.3.0',
+    'typing>=3.5.2',
+]
 
 with open('LICENSE') as f:
     license = f.read()

--- a/stone/cli_helpers.py
+++ b/stone/cli_helpers.py
@@ -1,5 +1,6 @@
 import abc
 import six
+from typing import Tuple
 
 from ply import lex, yacc
 
@@ -10,16 +11,22 @@ class FilterExprLexer(object):
         'ID',
         'LPAR',
         'RPAR',
+    )  # type: Tuple[str, ...]
 
-        # Conjunctions
+    # Conjunctions
+    tokens += (
         'AND',
         'OR',
+    )
 
-        # Comparison operators
+    # Comparison operators
+    tokens += (
         'NEQ',
         'EQ',
+    )
 
-        # Primitive types
+    # Primitive types
+    tokens += (
         'BOOLEAN',
         'FLOAT',
         'INTEGER',

--- a/stone/cli_helpers.py
+++ b/stone/cli_helpers.py
@@ -10,22 +10,16 @@ class FilterExprLexer(object):
         'ID',
         'LPAR',
         'RPAR',
-    )
 
-    # Conjunctions
-    tokens += (
+        # Conjunctions
         'AND',
         'OR',
-    )
 
-    # Comparison operators
-    tokens += (
+        # Comparison operators
         'NEQ',
         'EQ',
-    )
 
-    # Primitive types
-    tokens += (
+        # Primitive types
         'BOOLEAN',
         'FLOAT',
         'INTEGER',

--- a/stone/generator.py
+++ b/stone/generator.py
@@ -60,7 +60,8 @@ def remove_aliases_from_api(api):
     return api
 
 
-class Generator(six.with_metaclass(ABCMeta)):
+@six.add_metaclass(ABCMeta)
+class Generator(object):
     """
     The parent class for all generators. All generators should extend this
     class to be recognized as such.

--- a/stone/lang/lexer.py
+++ b/stone/lang/lexer.py
@@ -5,6 +5,8 @@ import os
 
 import ply.lex as lex
 
+from typing import Tuple
+
 class MultiToken(object):
     """Object used to monkeypatch ply.lex so that we can return multiple
     tokens from one lex operation."""
@@ -100,41 +102,31 @@ class StoneLexer(object):
         'KEYWORD',
         'PATH',
         'DOT',
-    )
 
-    # Whitespace tokens
-    tokens += (
+        # Whitespace tokens
         'DEDENT',
         'INDENT',
         'NEWLINE',
-    )
 
-    # Attribute lists, aliases
-    tokens += (
+        # Attribute lists, aliases
         'COMMA',
         'EQ',
         'LPAR',
         'RPAR',
-    )
 
-    # Primitive types
-    tokens += (
+        # Primitive types
         'BOOLEAN',
         'FLOAT',
         'INTEGER',
         'NULL',
         'STRING',
-    )
 
-    # List notation
-    tokens += (
+        # List notation
         'LBRACKET',
         'RBRACKET',
-    )
 
-    tokens += (
         'Q',
-    )
+    )  # type: Tuple[str, ...]
 
     # Regular expression rules for simple tokens
     t_DOT = r'\.'

--- a/stone/lang/lexer.py
+++ b/stone/lang/lexer.py
@@ -102,31 +102,41 @@ class StoneLexer(object):
         'KEYWORD',
         'PATH',
         'DOT',
+    )  # type: Tuple[str, ...]
 
-        # Whitespace tokens
+    # Whitespace tokens
+    tokens += (
         'DEDENT',
         'INDENT',
         'NEWLINE',
+    )
 
-        # Attribute lists, aliases
+    # Attribute lists, aliases
+    tokens += (
         'COMMA',
         'EQ',
         'LPAR',
         'RPAR',
+    )
 
-        # Primitive types
+    # Primitive types
+    tokens += (
         'BOOLEAN',
         'FLOAT',
         'INTEGER',
         'NULL',
         'STRING',
+    )
 
-        # List notation
+    # List notation
+    tokens += (
         'LBRACKET',
         'RBRACKET',
+    )
 
+    tokens += (
         'Q',
-    )  # type: Tuple[str, ...]
+    )
 
     # Regular expression rules for simple tokens
     t_DOT = r'\.'

--- a/stone/target/python_rsrc/stone_base.py
+++ b/stone/target/python_rsrc/stone_base.py
@@ -13,7 +13,7 @@ try:
 except (SystemError, ValueError):
     # Catch errors raised when importing a relative module when not in a package.
     # This makes testing this file directly (outside of a package) easier.
-    import stone_validators as bv
+    import stone_validators as bv  # type: ignore
 
 
 class Union(object):

--- a/stone/target/python_rsrc/stone_serializers.py
+++ b/stone/target/python_rsrc/stone_serializers.py
@@ -24,7 +24,7 @@ try:
 except (SystemError, ValueError):
     # Catch errors raised when importing a relative module when not in a package.
     # This makes testing this file directly (outside of a package) easier.
-    import stone_validators as bv
+    import stone_validators as bv  # type: ignore
 
 
 # --------------------------------------------------------------

--- a/stone/target/python_rsrc/stone_validators.py
+++ b/stone/target/python_rsrc/stone_validators.py
@@ -18,6 +18,7 @@ import math
 import numbers
 import re
 import six
+from typing import Optional
 
 if six.PY3:
     _binary_types = (bytes, memoryview)
@@ -121,8 +122,8 @@ class Integer(Primitive):
     Do not use this class directly. Extend it and specify a 'minimum' and
     'maximum' value as class variables for a more restrictive integer range.
     """
-    minimum = None
-    maximum = None
+    minimum = None  # type: Optional[numbers.Integral]
+    maximum = None  # type: Optional[numbers.Integral]
 
     def __init__(self, min_value=None, max_value=None):
         """
@@ -183,8 +184,8 @@ class Real(Primitive):
     and 'maximum' value to enforce a range that's a subset of the Python float
     implementation. Python floats are doubles.
     """
-    minimum = None
-    maximum = None
+    minimum = None  # type: Optional[numbers.Real]
+    maximum = None  # type: Optional[numbers.Real]
 
     def __init__(self, min_value=None, max_value=None):
         """


### PR DESCRIPTION
Just wanted to clean up any errors it was throwing by default. 

(If you're curious what the mypy-run.sh script picks up, it is:
```
+ mypy --strict-optional --silent-imports --fast-parser setup.py stone/__init__.py stone/api.py stone/cli.py stone/cli_helpers.py stone/compiler.py stone/data_type.py stone/generator.py stone/lang/__init__.py stone/lang/exception.py stone/lang/lexer.py stone/lang/parser.py stone/lang/tower.py stone/target/__init__.py stone/target/helpers.py stone/target/js_client.py stone/target/js_helpers.py stone/target/python_client.py stone/target/python_helpers.py stone/target/python_rsrc/__init__.py stone/target/python_rsrc/stone_base.py stone/target/python_rsrc/stone_serializers.py stone/target/python_rsrc/stone_validators.py stone/target/python_types.py stone/target/swift.py stone/target/swift_client.py stone/target/swift_helpers.py stone/target/swift_types.py test/test_cli.py test/test_generator.py test/test_python_gen.py test/test_stone.py test/test_stone_internal.py
```