### PR TITLE
Fix: Reference to CalcError should be EvalError

### DIFF
--- a/doc/builtin_generators.rst
+++ b/doc/builtin_generators.rst
@@ -70,7 +70,7 @@ contents::
 
     namespace calc
 
-    route eval(Expression, Result, CalcError)
+    route eval(Expression, Result, EvalError)
 
     struct Expression
         "This expression is limited to a binary operation."


### PR DESCRIPTION
Reference to CalcError should be EvalError or EvalError should be renamed CalcError, otherwise `stone python_types . calc.stone` does not work. 

Outputs:

`calc.stone:3: error: Symbol 'CalcError' is undefined.`