### PR TITLE
Update serializer architecture

### DIFF
--- a/stone/target/python_rsrc/stone_serializers.py
+++ b/stone/target/python_rsrc/stone_serializers.py
@@ -18,17 +18,344 @@ import datetime
 import functools
 import json
 import six
+import typing  # pylint: disable=unused-import
 
 try:
+    from . import stone_base as bb  # pylint: disable=unused-import
     from . import stone_validators as bv
 except (SystemError, ValueError):
     # Catch errors raised when importing a relative module when not in a package.
     # This makes testing this file directly (outside of a package) easier.
+    import stone_validators as bb  # type: ignore # pylint: disable=unused-import
     import stone_validators as bv  # type: ignore
 
+#-------------------------------------------------------------------------
+class StoneEncoderInterface(object):
+    """
+    Interface defining a stone object encoder.
+    """
+
+    def encode(self, validator, value):
+        # type: (bv.Validator, typing.Any) -> typing.Any
+        """
+        Validate ``value`` using ``validator`` and return the encoding.
+
+        Args:
+            validator: the ``stone_validators.Validator`` used to validate
+                ``value``
+            value: the object to encode
+
+        Returns:
+            The encoded object. This is implementation-defined.
+
+        Raises:
+            stone_validators.ValidationError: Raised if ``value`` (or one
+                of its sub-values).
+        """
+        raise NotImplementedError
+
+#-------------------------------------------------------------------------
+class StoneSerializerBase(StoneEncoderInterface):
+
+    def __init__(self, alias_validators=None):
+        # type: (typing.Mapping[bv.Validator, typing.Callable[[typing.Any], None]]) -> None
+        """
+        Constructor, `obviously
+        <http://www.geekalerts.com/ew-hand-sanitizer/>`.
+
+        Args:
+            alias_validators (``typing.Mapping``, optional): A mapping of
+                custom validation callables in the format
+                ``{stone_validators.Validator:
+                typing.Callable[[typing.Any], None], ...}``. These callables must
+                raise a ``stone_validators.ValidationError`` on failure.
+                Defaults to ``None``.
+        """
+        self._alias_validators = {}  # type: typing.Dict[bv.Validator, typing.Callable[[typing.Any], None]]
+
+        if alias_validators is not None:
+            self._alias_validators.update(alias_validators)
+
+    @property
+    def alias_validators(self):
+        """
+        A ``typing.Mapping`` of custom validation callables in the format
+        ``{stone_validators.Validator: typing.Callable[typing.Any],
+        ...}``.
+        """
+        return self._alias_validators
+
+    def encode(self, validator, value):
+        return self.encode_sub(validator, value)
+
+    def encode_sub(self, validator, value):
+        # type: (bv.Validator, typing.Any) -> typing.Any
+        """
+        Callback intended to be called by other ``encode`` methods to
+        delegate encoding of sub-values. Arguments have the same semantics
+        as with the ``encode`` method.
+        """
+        if isinstance(validator, bv.List):
+            # Because Lists are mutable, we always validate them during
+            # serialization
+            validate_f = validator.validate
+            encode_f = self.encode_list
+        elif isinstance(validator, bv.Nullable):
+            validate_f = validator.validate
+            encode_f = self.encode_nullable
+        elif isinstance(validator, bv.Primitive):
+            validate_f = validator.validate
+            encode_f = self.encode_primitive
+        elif isinstance(validator, bv.Struct):
+            if isinstance(validator, bv.StructTree):
+                validate_f = validator.validate
+                encode_f = self.encode_struct_tree
+            else:
+                # Fields are already validated on assignment
+                validate_f = validator.validate_type_only
+                encode_f = self.encode_struct
+        elif isinstance(validator, bv.Union):
+            # Fields are already validated on assignment
+            validate_f = validator.validate_type_only
+            encode_f = self.encode_union
+        else:
+            raise bv.ValidationError('Unsupported data type {}'.format(type(validator).__name__))
+
+        validate_f(value)
+
+        return encode_f(validator, value)
+
+    def encode_list(self, validator, value):
+        # type: (bv.List, typing.Any) -> typing.Any
+        """
+        Callback for serializing a ``stone_validators.List``. Arguments
+        have the same semantics as with the ``encode`` method.
+        """
+        raise NotImplementedError
+
+    def encode_nullable(self, validator, value):
+        # type: (bv.Nullable, typing.Any) -> typing.Any
+        """
+        Callback for serializing a ``stone_validators.Nullable``.
+        Arguments have the same semantics as with the ``encode`` method.
+        """
+        raise NotImplementedError
+
+    def encode_primitive(self, validator, value):
+        # type: (bv.Primitive, typing.Any) -> typing.Any
+        """
+        Callback for serializing a ``stone_validators.Primitive``.
+        Arguments have the same semantics as with the ``encode`` method.
+        """
+        raise NotImplementedError
+
+    def encode_struct(self, validator, value):
+        # type: (bv.Struct, typing.Any) -> typing.Any
+        """
+        Callback for serializing a ``stone_validators.Struct``. Arguments
+        have the same semantics as with the ``encode`` method.
+        """
+        raise NotImplementedError
+
+    def encode_struct_tree(self, validator, value):
+        # type: (bv.StructTree, typing.Any) -> typing.Any
+        """
+        Callback for serializing a ``stone_validators.StructTree``.
+        Arguments have the same semantics as with the ``encode`` method.
+        """
+        raise NotImplementedError
+
+    def encode_union(self, validator, value):
+        # type: (bv.Union, bb.Union) -> typing.Any
+        """
+        Callback for serializing a ``stone_validators.Union``. Arguments
+        have the same semantics as with the ``encode`` method.
+        """
+        raise NotImplementedError
+
+#-------------------------------------------------------------------------
+class StoneToPythonPrimitiveSerializer(StoneSerializerBase):
+
+    def __init__(self, alias_validators=None, for_msgpack=False, old_style=False):
+        # type: (typing.Mapping[bv.Validator, typing.Callable[[typing.Any], None]], bool, bool) -> None
+        """
+        Args:
+            alias_validators (``typing.Mapping``, optional): Passed
+                to ``StoneSerializer.__init__``. Defaults to ``None``.
+            for_msgpack (bool, optional): See the like-named property.
+                Defaults to ``False``.
+            old_style (bool, optional): See the like-named property.
+                Defaults to ``False``.
+        """
+        super(StoneToPythonPrimitiveSerializer, self).__init__(alias_validators=alias_validators)
+        self._for_msgpack = for_msgpack
+        self._old_style = old_style
+
+    @property
+    def for_msgpack(self):
+        """
+        EXPERIMENTAL: A flag associated with the serializer indicating
+        whether objects produced by the ``encode`` method should be
+        encoded for msgpack.
+
+        """
+        return self._for_msgpack
+
+    @property
+    def old_style(self):
+        """
+        A flag associated with the serializer indicating whether objects
+        produced by the ``encode`` method should be encoded according to
+        Dropbox's old or new API styles.
+        """
+        return self._old_style
+
+    def encode_list(self, validator, value):
+        validated_value = validator.validate(value)
+
+        return [self.encode_sub(validator.item_validator, value_item) for value_item in
+                validated_value]
+
+    def encode_nullable(self, validator, value):
+        if value is None:
+            return None
+
+        return self.encode_sub(validator.validator, value)
+
+    def encode_primitive(self, validator, value):
+        if validator in self.alias_validators:
+            self.alias_validators[validator](value)
+
+        if isinstance(validator, bv.Void):
+            return None
+        elif isinstance(validator, bv.Timestamp):
+            return value.strftime(validator.format)
+        elif isinstance(validator, bv.Bytes):
+            if self.for_msgpack:
+                return value
+            else:
+                return base64.b64encode(value).decode('ascii')
+        elif isinstance(validator, bv.Integer) \
+                    and isinstance(value, bool):
+            # bool is sub-class of int so it passes Integer validation,
+            # but we want the bool to be encoded as ``0`` or ``1``, rather
+            # than ``False`` or ``True``, respectively
+            return int(value)
+        else:
+            return value
+
+    def encode_struct(self, validator, value):
+        # Skip validation of fields with primitive data types because
+        # they've already been validated on assignment
+        d = collections.OrderedDict()  # type: typing.Dict[str, typing.Any]
+
+        # pylint: disable=protected-access
+        for field_name, field_validator in validator.definition._all_fields_:
+            try:
+                field_value = getattr(value, field_name)
+            except AttributeError as exc:
+                raise bv.ValidationError(exc.args[0])
+
+            presence_key = '_%s_present' % field_name
+
+            if field_value is not None \
+                    and getattr(value, presence_key):
+                # Only serialize struct fields that have been explicitly
+                # set, even if there is a default
+                try:
+                    d[field_name] = self.encode_sub(field_validator, field_value)
+                except bv.ValidationError as exc:
+                    exc.add_parent(field_name)
+
+                    raise
+        return d
+
+    def encode_struct_tree(self, validator, value):
+        # pylint: disable=protected-access
+        assert type(value) in validator.definition._pytype_to_tag_and_subtype_, \
+            '%r is not a serializable subtype of %r.' % (type(value), validator.definition)
+
+        tags, subtype = validator.definition._pytype_to_tag_and_subtype_[type(value)]
+
+        assert len(tags) == 1, tags
+        assert not isinstance(subtype, bv.StructTree), \
+            'Cannot serialize type %r because it enumerates subtypes.' % subtype.definition
+
+        if self.old_style:
+            d = {
+                tags[0]: self.encode_struct(subtype, value),
+            }
+        else:
+            d = collections.OrderedDict()
+            d['.tag'] = tags[0]
+            d.update(self.encode_struct(subtype, value))
+
+        return d
+
+    def encode_union(self, validator, value):
+        # pylint: disable=protected-access
+        if value._tag is None:
+            raise bv.ValidationError('no tag set')
+
+        field_validator = validator.definition._tagmap[value._tag]
+        is_none = isinstance(field_validator, bv.Void) \
+                or (isinstance(field_validator, bv.Nullable) \
+                    and value._value is None)
+
+        def encode_sub(sub_validator, sub_value, parent_tag):
+            try:
+                encoded_val = self.encode_sub(sub_validator, sub_value)
+            except bv.ValidationError as exc:
+                exc.add_parent(parent_tag)
+
+                raise
+            else:
+                return encoded_val
+
+        if self.old_style:
+            if field_validator is None:
+                return value._tag
+            elif is_none:
+                return value._tag
+            else:
+                encoded_val = encode_sub(field_validator, value._value, value._tag)
+
+                return {value._tag: encoded_val}
+        elif is_none:
+            return {'.tag': value._tag}
+        else:
+            encoded_val = encode_sub(field_validator, value._value, value._tag)
+
+            if isinstance(field_validator, bv.Nullable):
+                # We've already checked for the null case above,
+                # so now we're only interested in what the
+                # wrapped validator is
+                field_validator = field_validator.validator
+
+            if isinstance(field_validator, bv.Struct) \
+                    and not isinstance(field_validator, bv.StructTree):
+                d = collections.OrderedDict()  # type: typing.Dict[str, typing.Any]
+                d['.tag'] = value._tag
+                d.update(encoded_val)
+
+                return d
+            else:
+                return collections.OrderedDict((
+                    ('.tag', value._tag),
+                    (value._tag, encoded_val),
+                ))
+
+#-------------------------------------------------------------------------
+class StoneToJsonSerializer(StoneToPythonPrimitiveSerializer):
+
+    def encode(self, validator, value):
+        return json.dumps(super(StoneToJsonSerializer, self).encode(validator, value))
 
 # --------------------------------------------------------------
 # JSON Encoder
+#
+# These interfaces are preserved for backward compatibility and symmetry with deserialization
+# functions.
 
 def json_encode(data_type, obj, alias_validators=None, old_style=False):
     """Encodes an object into JSON based on its type.
@@ -81,10 +408,9 @@ def json_encode(data_type, obj, alias_validators=None, old_style=False):
     > JsonEncoder.encode(um)
     "{'update': {'path': 'a/b/c', 'rev': '1234'}}"
     """
-    return json.dumps(
-        json_compat_obj_encode(
-            data_type, obj, alias_validators, old_style))
-
+    for_msgpack = False
+    serializer = StoneToJsonSerializer(alias_validators, for_msgpack, old_style)
+    return serializer.encode(data_type, obj)
 
 def json_compat_obj_encode(
         data_type, obj, alias_validators=None, old_style=False,
@@ -101,223 +427,8 @@ def json_compat_obj_encode(
 
     See json_encode() for additional information about validation.
     """
-    if isinstance(data_type, (bv.Struct, bv.Union)):
-        # Only validate the type because fields are validated on assignment.
-        data_type.validate_type_only(obj)
-    else:
-        data_type.validate(obj)
-    return _json_compat_obj_encode_helper(
-        data_type, obj, alias_validators, old_style, for_msgpack)
-
-
-def _json_compat_obj_encode_helper(
-        data_type, obj, alias_validators, old_style, for_msgpack):
-    """
-    See json_encode() for argument descriptions.
-    """
-    if isinstance(data_type, bv.List):
-        return _encode_list(
-            data_type, obj, alias_validators, old_style=old_style,
-            for_msgpack=for_msgpack)
-    elif isinstance(data_type, bv.Nullable):
-        return _encode_nullable(
-            data_type, obj, alias_validators, old_style=old_style,
-            for_msgpack=for_msgpack)
-    elif isinstance(data_type, bv.Primitive):
-        return _make_json_friendly(
-            data_type, obj, alias_validators, for_msgpack=for_msgpack)
-    elif isinstance(data_type, bv.StructTree):
-        return _encode_struct_tree(
-            data_type, obj, alias_validators, old_style=old_style,
-            for_msgpack=for_msgpack)
-    elif isinstance(data_type, bv.Struct):
-        return _encode_struct(
-            data_type, obj, alias_validators, old_style=old_style,
-            for_msgpack=for_msgpack)
-    elif isinstance(data_type, bv.Union):
-        if old_style:
-            return _encode_union_old(
-                data_type, obj, alias_validators, for_msgpack=for_msgpack)
-        else:
-            return _encode_union(
-                data_type, obj, alias_validators, for_msgpack=for_msgpack)
-    else:
-        raise AssertionError('Unsupported data type %r' %
-                             type(data_type).__name__)
-
-
-def _encode_list(data_type, obj, alias_validators, old_style, for_msgpack):
-    """
-    The data_type argument must be a List.
-    See json_encode() for argument descriptions.
-    """
-    # Because Lists are mutable, we always validate them during serialization.
-    obj = data_type.validate(obj)
-    return [
-        _json_compat_obj_encode_helper(
-            data_type.item_validator, item, alias_validators, old_style, for_msgpack)
-        for item in obj
-    ]
-
-
-def _encode_nullable(data_type, obj, alias_validators, old_style, for_msgpack):
-    """
-    The data_type argument must be a Nullable.
-    See json_encode() for argument descriptions.
-    """
-    if obj is not None:
-        return _json_compat_obj_encode_helper(
-            data_type.validator, obj, alias_validators, old_style, for_msgpack)
-    else:
-        return None
-
-
-def _encode_struct(data_type, obj, alias_validators, old_style, for_msgpack):
-    """
-    The data_type argument must be a Struct or StructTree.
-    See json_encode() for argument descriptions.
-    """
-    # We skip validation of fields with primitive data types in structs and
-    # unions because they've already been validated on assignment.
-    d = collections.OrderedDict()
-    for field_name, field_data_type in data_type.definition._all_fields_:
-        try:
-            val = getattr(obj, field_name)
-        except AttributeError as e:
-            raise bv.ValidationError(e.args[0])
-        presence_key = '_%s_present' % field_name
-        if val is not None and getattr(obj, presence_key):
-            # This check makes sure that we don't serialize absent struct
-            # fields as null, even if there is a default.
-            try:
-                d[field_name] = _json_compat_obj_encode_helper(
-                    field_data_type, val, alias_validators, old_style,
-                    for_msgpack)
-            except bv.ValidationError as e:
-                e.add_parent(field_name)
-                raise
-    return d
-
-
-def _encode_union(data_type, obj, alias_validators, for_msgpack):
-    """
-    The data_type argument must be a Union.
-    See json_encode() for argument descriptions.
-    """
-    if obj._tag is None:
-        raise bv.ValidationError('no tag set')
-    field_data_type = data_type.definition._tagmap[obj._tag]
-
-    if (isinstance(field_data_type, bv.Void) or
-            (isinstance(field_data_type, bv.Nullable) and obj._value is None)):
-        return {'.tag': obj._tag}
-    else:
-        try:
-            encoded_val = _json_compat_obj_encode_helper(
-                field_data_type, obj._value, alias_validators, False,
-                for_msgpack)
-        except bv.ValidationError as e:
-            e.add_parent(obj._tag)
-            raise
-        else:
-            if isinstance(field_data_type, bv.Nullable):
-                # We've already checked for the null case above, so now we're
-                # only interested in what the wrapped validator is.
-                field_data_type = field_data_type.validator
-            if (isinstance(field_data_type, bv.Struct) and
-                    not isinstance(field_data_type, bv.StructTree)):
-                d = collections.OrderedDict()
-                d['.tag'] = obj._tag
-                d.update(encoded_val)
-                return d
-            else:
-                return collections.OrderedDict([
-                    ('.tag', obj._tag),
-                    (obj._tag, encoded_val)])
-
-
-def _encode_union_old(data_type, obj, alias_validators, for_msgpack):
-    """
-    The data_type argument must be a Union.
-    See json_encode() for argument descriptions.
-    """
-    if obj._tag is None:
-        raise bv.ValidationError('no tag set')
-    field_data_type = data_type.definition._tagmap[obj._tag]
-    if field_data_type is None:
-        return obj._tag
-    else:
-        if (isinstance(field_data_type, bv.Void) or
-                (isinstance(field_data_type, bv.Nullable) and
-                 obj._value is None)):
-            return obj._tag
-        else:
-            try:
-                encoded_val = _json_compat_obj_encode_helper(
-                    field_data_type, obj._value, alias_validators, True,
-                    for_msgpack)
-            except bv.ValidationError as e:
-                e.add_parent(obj._tag)
-                raise
-            else:
-                return {obj._tag: encoded_val}
-
-
-def _encode_struct_tree(
-        data_type, obj, alias_validators, old_style, for_msgpack):
-    """
-    Args:
-        data_type (StructTree)
-        as_root (bool): If a struct with enumerated subtypes is designated as a
-            root, then its fields including those that are inherited are
-            encoded in the outermost JSON object together.
-
-    See json_encode() for other argument descriptions.
-    """
-    assert type(obj) in data_type.definition._pytype_to_tag_and_subtype_, (
-        '%r is not a serializable subtype of %r.' %
-        (type(obj), data_type.definition))
-    tags, subtype = data_type.definition._pytype_to_tag_and_subtype_[type(obj)]
-    assert len(tags) == 1, tags
-    assert not isinstance(subtype, bv.StructTree), (
-        'Cannot serialize type %r because it enumerates subtypes.' %
-        subtype.definition)
-    if old_style:
-        return {
-            tags[0]:
-                _encode_struct(
-                    subtype, obj, alias_validators, old_style, for_msgpack)
-        }
-    d = collections.OrderedDict()
-    d['.tag'] = tags[0]
-    d.update(
-        _encode_struct(subtype, obj, alias_validators, old_style, for_msgpack))
-    return d
-
-
-def _make_json_friendly(data_type, val, alias_validators, for_msgpack):
-    """
-    Convert a primitive type to a Python type that can be serialized by the
-    json package.
-    """
-    if alias_validators is not None and data_type in alias_validators:
-        alias_validators[data_type](val)
-    if isinstance(data_type, bv.Void):
-        return None
-    elif isinstance(data_type, bv.Timestamp):
-        return val.strftime(data_type.format)
-    elif isinstance(data_type, bv.Bytes):
-        if for_msgpack:
-            return val
-        else:
-            return base64.b64encode(val).decode('ascii')
-    elif isinstance(data_type, bv.Integer) and isinstance(val, bool):
-        # A bool is a subclass of an int so it passes Integer validation. But,
-        # we want the bool to be encoded as an Integer (1/0) rather than T/F.
-        return int(val)
-    else:
-        return val
-
+    serializer = StoneToPythonPrimitiveSerializer(alias_validators, for_msgpack, old_style)
+    return serializer.encode(data_type, obj)
 
 # --------------------------------------------------------------
 # JSON Decoder
@@ -433,6 +544,7 @@ def _decode_struct(
                                  bv.generic_type_name(obj))
     if strict:
         for key in obj:
+            # pylint: disable=protected-access
             if (key not in data_type.definition._all_field_names_ and
                     not key.startswith('.tag')):
                 raise bv.ValidationError("unknown field '%s'" % key)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import unittest
@@ -124,3 +126,6 @@ class TestCLI(unittest.TestCase):
         self.assertTrue(expr.eval(MockRoute({'a': 2, 'b': 3, 'c': 4})))
         self.assertFalse(expr.eval(MockRoute({'a': 1})))
         self.assertFalse(expr.eval(MockRoute({'a': 1, 'b': 3})))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
@@ -213,3 +215,6 @@ int sq(int x) <
     def test_generator_cmdline(self):
         t = TesterCmdline(None, ['-v'])
         self.assertTrue(t.args.verbose)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_python_gen.py
+++ b/test/test_python_gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import base64
@@ -1293,3 +1295,6 @@ class TestGeneratedPython(unittest.TestCase):
     def test_struct_union_default(self):
         s = self.ns.S3()
         assert s.u == self.ns2.BaseU.z
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
@@ -3389,3 +3391,6 @@ class TestStone(unittest.TestCase):
             cm.exception.msg)
         self.assertEqual(cm.exception.lineno, 9)
         self.assertEqual(cm.exception.path, 'ns1.stone')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_stone_internal.py
+++ b/test/test_stone_internal.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import unittest
@@ -475,3 +477,6 @@ class TestStoneInternal(unittest.TestCase):
         # test that dict is returned for a tagged struct variant
         self.assertEqual(conflict.get_examples()['default'].value,
             {'.tag': 'update_if_matching_parent_rev', 'parent_rev': 'xyz123'})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This replaces the function-based serialization code with an extensible object-oriented framework. Older public interfaces are preserved for backward compatibility.

Because the existing `json_encode` interface is now implemented in terms of the new architecture, the existing tests should provide coverage.