### PR TITLE
READY FOR REVIEW - Remove typing as runtime dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.cache
+/.eggs
 /.tox
 /.tox-*
 /.venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+# See http://doc.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,14 @@ from setuptools import setup
 install_reqs = [
     'ply>=3.4',
     'six>=1.3.0',
-    'typing>=3.5.2',
+]
+
+setup_requires = [
+    'pytest-runner',
+]
+
+test_reqs = [
+    'pytest',
 ]
 
 with open('LICENSE') as f:
@@ -36,6 +43,8 @@ dist = setup(
     maintainer_email='dev-platform@dropbox.com',
     url='https://github.com/dropbox/stone',
     install_requires=install_reqs,
+    setup_requires=setup_requires,
+    tests_require=test_reqs,
     license=LICENSE,
     zip_safe=False,
     packages=['stone',

--- a/stone/api.py
+++ b/stone/api.py
@@ -4,12 +4,8 @@ from collections import OrderedDict
 # See <https://github.com/PyCQA/pylint/issues/73>
 from distutils.version import StrictVersion  # pylint: disable=import-error,no-name-in-module
 import six
-import typing
 
 from stone.data_type import (
-    List as DataTypeList,
-    Nullable,
-    UserDefined,
     doc_unwrap,
     is_alias,
     is_composite_type,
@@ -17,16 +13,21 @@ from stone.data_type import (
     is_nullable_type,
 )
 
-from stone.data_type import (  # noqa: F401 # pylint: disable=unused-import
-    Alias,
-    DataType,
-    Struct,
-)
+_MYPY = False
+if _MYPY:
+    import typing  # pylint: disable=import-error,useless-suppression
 
-from stone.lang.parser import StoneRouteDef  # noqa: F401 # pylint: disable=unused-import
+    from stone.data_type import (  # noqa: F401 # pylint: disable=unused-import
+        Alias,
+        DataType,
+        List as DataTypeList,
+        Nullable,
+        UserDefined,
+        Struct,
+    )
 
-__MYPY = False
-if __MYPY:
+    from stone.lang.parser import StoneRouteDef  # noqa: F401 # pylint: disable=unused-import
+
     # TODO: This can be changed back to a single declaration with a
     # unicode literal after <https://github.com/python/mypy/pull/2516>
     # makes it into a PyPi release
@@ -229,10 +230,11 @@ class ApiNamespace(object):
             for dtype in (route.arg_data_type, route.result_data_type,
                           route.error_data_type):
                 while is_list_type(dtype) or is_nullable_type(dtype):
-                    dtype_as_list = typing.cast(typing.Union[DataTypeList, Nullable], dtype)
-                    dtype = dtype_as_list.data_type
+                    data_list_type = dtype  # type: typing.Any
+                    dtype = data_list_type.data_type
                 if is_composite_type(dtype) or is_alias(dtype):
-                    data_types.add(typing.cast(UserDefined, dtype))
+                    data_user_type = dtype  # type: typing.Any
+                    data_types.add(data_user_type)
 
         return sorted(data_types, key=lambda dt: dt.name)
 

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -13,19 +13,22 @@ import six
 import sys
 import traceback
 
+from .cli_helpers import parse_route_attr_filter
+from .compiler import Compiler, GeneratorException
+from .lang.exception import InvalidSpec
+from .lang.tower import TowerOfStone
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where
 # actually passing such literals results in errors with mypy --py2. See
 # <https://github.com/python/typeshed/issues/756> and
 # <https://github.com/python/mypy/issues/2536>.
 import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
 argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
-from .cli_helpers import parse_route_attr_filter
-from .compiler import Compiler, GeneratorException
-from .lang.exception import InvalidSpec
-from .lang.tower import TowerOfStone
 
 # These generators come by default
 _builtin_generators = (

--- a/stone/cli_helpers.py
+++ b/stone/cli_helpers.py
@@ -1,8 +1,11 @@
 import abc
 import six
-import typing  # noqa: F401 # pylint: disable=unused-import
 
 from ply import lex, yacc
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 
 class FilterExprLexer(object):

--- a/stone/data_type.py
+++ b/stone/data_type.py
@@ -15,7 +15,6 @@ import math
 import numbers
 import re
 import six
-import typing  # noqa: F401 # pylint: disable=unused-import
 
 from .lang.exception import InvalidSpec
 from .lang.parser import (
@@ -23,6 +22,10 @@ from .lang.parser import (
     StoneExampleRef,
     StoneTagRef,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 
 class ParameterError(Exception):

--- a/stone/generator.py
+++ b/stone/generator.py
@@ -5,7 +5,21 @@ from contextlib import contextmanager
 import os
 import six
 import textwrap
-import typing
+
+from stone.lang.tower import doc_ref_re
+from stone.data_type import (
+    is_alias,
+)
+
+_MYPY = False
+if _MYPY:
+    from stone.api import Api  # noqa: F401 # pylint: disable=unused-import
+    import typing  # pylint: disable=import-error,useless-suppression
+
+    # Generic Dict key-val types
+    DelimTuple = typing.Tuple[typing.Text, typing.Text]
+    K = typing.TypeVar('K')
+    V = typing.TypeVar('V')
 
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where
@@ -17,19 +31,6 @@ argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 logging = importlib.import_module(str('logging'))  # type: typing.Any
 open = open  # type: typing.Any # pylint: disable=redefined-builtin
 
-from stone.api import Api  # noqa: F401 # pylint: disable=unused-import
-
-from stone.lang.tower import doc_ref_re
-from stone.data_type import (
-    is_alias,
-)
-
-__MYPY = False
-if __MYPY:
-    # Generic Dict key-val types
-    DelimTuple = typing.Tuple[typing.Text, typing.Text]
-    K = typing.TypeVar('K')
-    V = typing.TypeVar('V')
 
 def remove_aliases_from_api(api):
     for namespace in api.namespaces.values():

--- a/stone/lang/lexer.py
+++ b/stone/lang/lexer.py
@@ -2,9 +2,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-import typing  # noqa: F401 # pylint: disable=unused-import
 
 import ply.lex as lex
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
 
 class MultiToken(object):
     """Object used to monkeypatch ply.lex so that we can return multiple

--- a/stone/lang/tower.py
+++ b/stone/lang/tower.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import inspect
 import logging
-import typing  # noqa: F401 # pylint: disable=unused-import
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where

--- a/stone/target/js_client.py
+++ b/stone/target/js_client.py
@@ -1,15 +1,18 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+    from stone.api import ApiNamespace  # noqa: F401 # pylint: disable=unused-import
+
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where
 # actually passing such literals results in errors with mypy --py2. See
 # <https://github.com/python/typeshed/issues/756> and
 # <https://github.com/python/mypy/issues/2536>.
 import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
 argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
-from stone.api import ApiNamespace  # noqa: F401 # pylint: disable=unused-import
 from stone.generator import CodeGenerator
 from stone.target.js_helpers import (
     fmt_error_type,

--- a/stone/target/js_types.py
+++ b/stone/target/js_types.py
@@ -4,15 +4,6 @@ import json
 import six
 import sys
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.data_type import (
     is_user_defined_type,
     is_union_type,
@@ -26,6 +17,18 @@ from stone.target.js_helpers import (
     fmt_type,
     fmt_type_name,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 
 _cmdline_parser = argparse.ArgumentParser(prog='js-types-generator')

--- a/stone/target/obj_c_client.py
+++ b/stone/target/obj_c_client.py
@@ -2,15 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.data_type import (
     is_nullable_type,
     is_struct_type,
@@ -43,6 +34,19 @@ from stone.target.obj_c import (
     stone_warning,
     undocumented,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
+
 
 _cmdline_parser = argparse.ArgumentParser(
     prog='ObjC-client-generator',

--- a/stone/target/obj_c_types.py
+++ b/stone/target/obj_c_types.py
@@ -4,15 +4,6 @@ import json
 import os
 import shutil
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.data_type import (
     is_list_type,
     is_nullable_type,
@@ -60,6 +51,18 @@ from stone.target.obj_c import (
     ObjCBaseGenerator,
     undocumented,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 
 _cmdline_parser = argparse.ArgumentParser(prog='obj-c-types-generator')

--- a/stone/target/python_client.py
+++ b/stone/target/python_client.py
@@ -2,15 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import re
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.data_type import (
     is_nullable_type,
     is_struct_type,
@@ -30,6 +21,19 @@ from stone.target.python_helpers import (
 from stone.target.python_types import (
     class_name_for_data_type,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
+
 
 # This will be at the top of the generated file.
 base = """\

--- a/stone/target/python_rsrc/stone_base.py
+++ b/stone/target/python_rsrc/stone_base.py
@@ -8,14 +8,16 @@ than being added to a project.
 
 from __future__ import absolute_import, unicode_literals
 
-import typing  # noqa: F401 # pylint: disable=unused-import
-
 try:
     from . import stone_validators as bv
 except (SystemError, ValueError):
     # Catch errors raised when importing a relative module when not in a package.
     # This makes testing this file directly (outside of a package) easier.
     import stone_validators as bv  # type: ignore
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 
 class Union(object):

--- a/stone/target/python_rsrc/stone_serializers.py
+++ b/stone/target/python_rsrc/stone_serializers.py
@@ -20,7 +20,6 @@ import json
 import re
 import six
 import time
-import typing  # noqa: F401 # pylint: disable=unused-import
 
 try:
     from . import stone_base as bb  # noqa: F401 # pylint: disable=unused-import
@@ -30,6 +29,11 @@ except (SystemError, ValueError):
     # This makes testing this file directly (outside of a package) easier.
     import stone_validators as bb  # type: ignore # noqa: F401 # pylint: disable=unused-import
     import stone_validators as bv  # type: ignore
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
 
 # ------------------------------------------------------------------------
 class StoneEncoderInterface(object):

--- a/stone/target/python_rsrc/stone_validators.py
+++ b/stone/target/python_rsrc/stone_validators.py
@@ -18,7 +18,10 @@ import math
 import numbers
 import re
 import six
-import typing  # noqa: F401 # pylint: disable=unused-import
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 # See <http://python3porting.com/differences.html#buffer>
 if six.PY3:

--- a/stone/target/python_types.py
+++ b/stone/target/python_types.py
@@ -8,13 +8,16 @@ import os
 import re
 import shutil
 
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where
 # actually passing such literals results in errors with mypy --py2. See
 # <https://github.com/python/typeshed/issues/756> and
 # <https://github.com/python/mypy/issues/2536>.
 import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
 argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 from stone.api import ApiNamespace  # noqa: F401 # pylint: disable=unused-import
@@ -44,6 +47,7 @@ from stone.target.python_helpers import (
     fmt_obj,
     fmt_var,
 )
+
 
 # This will be at the top of every generated file.
 validators_import = """\

--- a/stone/target/swift_client.py
+++ b/stone/target/swift_client.py
@@ -2,15 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.data_type import (
     is_struct_type,
     is_union_type,
@@ -29,6 +20,18 @@ from stone.target.swift_helpers import (
     fmt_var,
     fmt_type,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 
 _cmdline_parser = argparse.ArgumentParser(

--- a/stone/target/swift_types.py
+++ b/stone/target/swift_types.py
@@ -6,15 +6,6 @@ import shutil
 
 from contextlib import contextmanager
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.data_type import (
     is_list_type,
     is_numeric_type,
@@ -37,6 +28,18 @@ from stone.target.swift import (
     SwiftBaseGenerator,
     undocumented,
 )
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 
 _cmdline_parser = argparse.ArgumentParser(prog='swift-types-generator')

--- a/stone/target/tsd_client.py
+++ b/stone/target/tsd_client.py
@@ -3,13 +3,16 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import re
 
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where
 # actually passing such literals results in errors with mypy --py2. See
 # <https://github.com/python/typeshed/issues/756> and
 # <https://github.com/python/mypy/issues/2536>.
 import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
 argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 from stone.generator import CodeGenerator

--- a/stone/target/tsd_types.py
+++ b/stone/target/tsd_types.py
@@ -6,13 +6,16 @@ import re
 import six
 import sys
 
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
 # Hack to get around some of Python 2's standard library modules that
 # accept ascii-encodable unicode literals in lieu of strs, but where
 # actually passing such literals results in errors with mypy --py2. See
 # <https://github.com/python/typeshed/issues/756> and
 # <https://github.com/python/mypy/issues/2536>.
 import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
 argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 from stone.api import ApiNamespace  # noqa: F401 # pylint: disable=unused-import

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -4,15 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-# Hack to get around some of Python 2's standard library modules that
-# accept ascii-encodable unicode literals in lieu of strs, but where
-# actually passing such literals results in errors with mypy --py2. See
-# <https://github.com/python/typeshed/issues/756> and
-# <https://github.com/python/mypy/issues/2536>.
-import importlib
-import typing  # noqa: F401 # pylint: disable=unused-import
-argparse = importlib.import_module(str('argparse'))  # type: typing.Any
-
 from stone.api import (
     ApiNamespace,
     ApiRoute,
@@ -25,6 +16,18 @@ from stone.data_type import (
     StructField,
 )
 from stone.generator import CodeGenerator
+
+_MYPY = False
+if _MYPY:
+    import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
+
+# Hack to get around some of Python 2's standard library modules that
+# accept ascii-encodable unicode literals in lieu of strs, but where
+# actually passing such literals results in errors with mypy --py2. See
+# <https://github.com/python/typeshed/issues/756> and
+# <https://github.com/python/mypy/issues/2536>.
+import importlib
+argparse = importlib.import_module(str('argparse'))  # type: typing.Any
 
 class _Tester(CodeGenerator):
     """A no-op generator used to test helper methods."""

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -19,7 +19,6 @@ from stone.lang.tower import (
     InvalidSpec,
     TowerOfStone,
 )
-from stone.lang.tower import TagRef  # noqa: F401 # pylint: disable=unused-import
 from stone.data_type import (
     Alias,
     Nullable,

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,7 @@ skip_missing_interpreters = true
 [testenv]
 
 commands =
-    py.test {posargs}
-
-deps =
-    pytest
+    python setup.py test {posargs}
 
 
 [testenv:check]
@@ -29,7 +26,7 @@ commands =
 deps =
     mypy-lang
     typed-ast < 1.0.0
-    # git+git://github.com/python/mypy.git@3cc52013c35dadda57964c7d4ae6c664bfc1329c
+    typing>=3.5.2
 
 usedevelop = true
 


### PR DESCRIPTION
DEPENDS ON #37. This removes `typing` as a runtime dependency of Stone so that Python 2.7 users do not have to install it unnecessarily. It is still a build/test dependency for those who chose to use take advantage of it.
