### PR TITLE
READY FOR REVIEW - Only run python setup.py check ... in 3.5+ on Travis CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,22 @@
 [tox]
 
-envlist = py{27,32,33,34,35,py,py3},check,lint
+envlist = py{27,32,33,34,35,py,py3},check,lint,mypy
 skip_missing_interpreters = true
+
+
+[flake8]
+ignore = E127,E128,E226,E231,E301,E302,E305,E402,E701,W503
+max-line-length = 100
 
 
 [tox:travis]
 
 2.7 = py27, lint
-3.3 = py33
-3.4 = py34, check, lint
-3.5 = py35
+pypy = pypy, lint
+3.3 = py33, lint, mypy
+3.4 = py34, lint, mypy
+3.5 = py35, check, lint, mypy
+pypy3 = pypy3, lint, mypy
 
 
 [testenv]
@@ -21,12 +28,10 @@ commands =
 [testenv:check]
 
 commands =
-    ./mypy-run.sh
+    python setup.py check -m -r -s -v
 
 deps =
-    mypy-lang
-    typed-ast < 1.0.0
-    typing>=3.5.2
+    docutils
 
 usedevelop = true
 
@@ -36,16 +41,22 @@ usedevelop = true
 commands =
     flake8 setup.py example stone test
     pylint --rcfile=.pylintrc setup.py example stone test
-    python setup.py check -m -r -s -v
 
 deps =
-    docutils==0.12
     flake8
     pylint
 
 usedevelop = true
 
 
-[flake8]
-ignore = E127,E128,E226,E231,E301,E302,E305,E402,E701,W503
-max-line-length = 100
+[testenv:mypy]
+
+commands =
+    ./mypy-run.sh
+
+deps =
+    mypy-lang
+    typed-ast < 1.0.0
+    typing >= 3.5.2
+
+usedevelop = true


### PR DESCRIPTION
The recent release of `docutils` 0.13.1 highlighted problems with
`distutils` that have been fixed, but those fixes have not made it
into Travis CI's "default" (i.e. those referred to without point
releases, e.g., "3.3") Python versions <=3.4.

This limits running `python setup.py check ...` to Python 3.5 only so
that we can safely remove the peg to `docutils` 0.12 without having to
target specific point releases in Travis CI.

Background:

* https://bugs.python.org/issue28981
* https://sourceforge.net/p/docutils/bugs/302/
* https://github.com/dropbox/stone/pull/28#discussion-diff-91844629L44
* https://github.com/travis-ci/travis-ci/issues/7028