### PR TITLE
Fix flake8 line-too-long failure on ObjC

### DIFF
--- a/stone/target/obj_c_types.py
+++ b/stone/target/obj_c_types.py
@@ -893,7 +893,9 @@ class ObjCTypesGenerator(ObjCBaseGenerator):
                     self.emit('jsonDict[@".tag"] = @"other";')
                 else:
                     self._generate_throw_error(
-                        'InvalidTag', '@"Object not properly initialized. Tag has an unknown value."')
+                        'InvalidTag',
+                        '@"Object not properly initialized. Tag has an unknown value."'
+                    )
 
             self.emit()
             self.emit('return jsonDict;')


### PR DESCRIPTION
Somebody pushed an objc change that overruns character limit:
```
lint runtests: commands[0] | flake8 setup.py example stone test

stone/target/obj_c_types.py:896:101: E501 line too long (102 > 100 characters)

ERROR: InvocationError: '/home/travis/build/dropbox/stone/.tox/lint/bin/flake8 setup.py example stone test'
```