### PR TITLE
include lists in make_compact

### DIFF
--- a/stone/data_type.py
+++ b/stone/data_type.py
@@ -785,6 +785,9 @@ class UserDefined(Composite):
                         d[key] = inner_d['.tag']
                     else:
                         make_compact(inner_d)
+                if isinstance(d[key], list):
+                    for item in d[key]:
+                        make_compact(item)
 
         for example in examples.values():
             if (isinstance(example.value, dict) and


### PR DESCRIPTION
fixes issue where a list of parameters doesn’t exclude unnecessary lone
.tag keys when generating examples