### PR TITLE
READY FOR REVIEW - Fix build error (`mypy-lang` -> `mypy`)

### DIFF
--- a/mypy-run.sh
+++ b/mypy-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
-EXCLUDE='(^example/|^ez_setup\.py$)'
+EXCLUDE='(^example/|^ez_setup\.py$|^setup\.py$)'
 
 # Include all Python files registered in Git, that don't occur in $EXCLUDE.
 INCLUDE=$(git ls-files "$@" | grep '\.py$' | grep -Ev "$EXCLUDE" | tr '\n' '\0' | xargs -0 | cat)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-fast_parser = True
+# follow_imports = False
+ignore_missing_imports = True
 show_none_errors = True
-silent_imports = True
 strict_optional = True

--- a/stone/backend.py
+++ b/stone/backend.py
@@ -292,7 +292,7 @@ class Backend(object):
 
     @classmethod
     def process_doc(cls, doc, handler):
-        # type: (str, typing.Callable[[str, str], str]) -> str
+        # type: (str, typing.Callable[[str, str], str]) -> typing.Text
         """
         Helper for parsing documentation references in Stone docstrings and
         replacing them with more suitable annotations for the generated output.

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -10,7 +10,8 @@ try:
     # Works for Py 3.3+
     from unittest.mock import Mock
 except ImportError:
-    from mock import Mock
+    # See https://github.com/python/mypy/issues/1153#issuecomment-253842414
+    from mock import Mock  # type: ignore
 
 from stone.ir import (
     Alias,

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,8 @@ commands =
     ./mypy-run.sh
 
 deps =
-    mypy-lang
-    typed-ast < 1.0.0
+    mypy
+    typed-ast
     typing >= 3.5.2
 
 usedevelop = true


### PR DESCRIPTION
This is a quick fix designed to unbreak builds. More scrutiny may be needed in the affected areas and should be handled in separate PRs. See my comments below regarding the individual changes for details.