### PR TITLE
Slight change to how we export routes.

### DIFF
--- a/stone/backends/js_client.py
+++ b/stone/backends/js_client.py
@@ -64,7 +64,7 @@ class JavascriptClientBackend(CodeBackend):
 
             self.emit()
 
-            self.emit('module.exports = routes;')
+            self.emit('export { routes };')
 
     def _generate_route(self, route_schema, namespace, route):
         function_name = fmt_func(namespace.name + '_' + route.name)


### PR DESCRIPTION
Use `export {routes}` vs `module.exports =` style