### PR TITLE
Add a flag to emit typescript fields in camelCase.

### DIFF
--- a/stone/backends/tsd_helpers.py
+++ b/stone/backends/tsd_helpers.py
@@ -40,6 +40,17 @@ _base_type_table = {
 }
 
 
+def fmt_name_case(name, use_camel_case):
+    # type: (str, bool) -> str
+    """
+    Camel case for variable names is the preferred style in typescript.
+    To keep generated code backwards compatible, camel casing is only enabled behind a flag.
+    """
+    if use_camel_case:
+        return fmt_camel(name)
+    return name
+
+
 def fmt_error_type(data_type, inside_namespace=None):
     """
     Converts the error type into a TypeScript type.
@@ -47,6 +58,7 @@ def fmt_error_type(data_type, inside_namespace=None):
     occurs in, or None if this parameter is not relevant.
     """
     return 'Error<%s>' % fmt_type(data_type, inside_namespace)
+
 
 def fmt_type_name(data_type, inside_namespace=None):
     """
@@ -65,6 +77,7 @@ def fmt_type_name(data_type, inside_namespace=None):
             fmted_type += '<' + fmt_type(data_type.data_type, inside_namespace) + '>'
         return fmted_type
 
+
 def fmt_polymorphic_type_reference(data_type, inside_namespace=None):
     """
     Produces a TypeScript type name for the meta-type that refers to the given
@@ -76,6 +89,7 @@ def fmt_polymorphic_type_reference(data_type, inside_namespace=None):
     #       can defer emitting these types until the end, and emit them in a
     #       nested namespace (e.g., files.references.MetadataReference).
     return fmt_type_name(data_type, inside_namespace) + "Reference"
+
 
 def fmt_type(data_type, inside_namespace=None):
     """
@@ -95,17 +109,21 @@ def fmt_type(data_type, inside_namespace=None):
     else:
         return fmt_type_name(data_type, inside_namespace)
 
+
 def fmt_union(type_strings):
     """
     Returns a union type of the given types.
     """
     return '|'.join(type_strings) if len(type_strings) > 1 else type_strings[0]
 
+
 def fmt_func(name):
     return fmt_camel(name)
 
+
 def fmt_var(name):
     return fmt_camel(name)
+
 
 def fmt_tag(cur_namespace, tag, val):
     """
@@ -130,6 +148,7 @@ def fmt_tag(cur_namespace, tag, val):
         return val
     else:
         raise RuntimeError('Unknown doc ref tag %r' % tag)
+
 
 def generate_imports_for_referenced_namespaces(backend, namespace):
     # type: (Backend, ApiNamespace) -> None

--- a/stone/backends/tsd_types.py
+++ b/stone/backends/tsd_types.py
@@ -32,6 +32,7 @@ from stone.backends.helpers import (
     fmt_pascal,
 )
 from stone.backends.tsd_helpers import (
+    fmt_name_case,
     fmt_polymorphic_type_reference,
     fmt_tag,
     fmt_type,
@@ -54,10 +55,16 @@ _cmdline_parser.add_argument(
           'all of the emitted types.'),
 )
 _cmdline_parser.add_argument(
-    '--exclude_error_types',
+    '--exclude-error-types',
     default=False,
     action='store_true',
     help='If true, the output will exclude the interface for Error type.',
+)
+_cmdline_parser.add_argument(
+    '--use-camel-case',
+    default=False,
+    action='store_true',
+    help='If true, field names will be emitted in camelCase style.',
 )
 _cmdline_parser.add_argument(
     '-e',
@@ -143,9 +150,13 @@ class TSDTypesBackend(CodeBackend):
     # Instance var to denote if one file is output for each namespace.
     split_by_namespace = False
 
+    # To ensure backwards compatibility, although ts style guide recommends camelCase.
+    use_camel_case = False
+
     def generate(self, api):
         extra_args = self._parse_extra_args(api, self.args.extra_arg)
         template = self._read_template()
+        self.use_camel_case = self.args.use_camel_case
         if self.args.filename:
             self._generate_base_namespace_module(api.namespaces.values(), self.args.filename,
                                                  template, extra_args,
@@ -338,7 +349,7 @@ class TSDTypesBackend(CodeBackend):
         """
         namespace = alias_type.namespace
         self.emit('export type %s = %s;' % (fmt_type_name(alias_type, namespace),
-                                     fmt_type_name(alias_type.data_type, namespace)))
+                                            fmt_type_name(alias_type.data_type, namespace)))
         self.emit()
 
     def _generate_struct_type(self, struct_type, indent_spaces, extra_parameters):
@@ -356,7 +367,8 @@ class TSDTypesBackend(CodeBackend):
             for param_name, param_type, param_docstring in extra_parameters:
                 if param_docstring:
                     self._emit_tsdoc_header(param_docstring)
-                self.emit('%s: %s;' % (param_name, param_type))
+                self.emit('%s: %s;' % (fmt_name_case(param_name, self.use_camel_case),
+                                       param_type))
 
             for field in struct_type.fields:
                 doc = field.doc
@@ -372,7 +384,8 @@ class TSDTypesBackend(CodeBackend):
                 if doc:
                     self._emit_tsdoc_header(doc)
                 # Translate nullable types into optional properties.
-                field_name = '%s?' % field.name if optional else field.name
+                cased_name = fmt_name_case(field.name, self.use_camel_case)
+                field_name = '%s?' % cased_name if optional else cased_name
                 self.emit('%s: %s;' % (field_name, field_ts_type))
 
         self.emit('}')
@@ -458,7 +471,8 @@ class TSDTypesBackend(CodeBackend):
                 # it in quotation marks.
                 self.emit("'.tag': '%s';" % variant.name)
                 if is_void_type(variant.data_type) is False:
-                    self.emit("%s: %s;" % (variant.name, fmt_type(variant.data_type, namespace)))
+                    self.emit("%s: %s;" % (fmt_name_case(variant.name, self.use_camel_case),
+                                           fmt_type(variant.data_type, namespace)))
             self.emit('}')
             self.emit()
 


### PR DESCRIPTION
The existing typescript backend emits struct field names in snake_case. This change adds a command line argument to change the style to camelCase. camelCase is the preferred convention in typescript for local variables.

New flag : `--use-camel-case`

The default value is set to False for backwards compatibility.

Updated existing tests and added a new test to verify camel case for struct, union fields when the flag is set.

@pran1990 