### PR TITLE
do not erronously include the requests.models.Response in the list of  return types for _to_file helper methods

### DIFF
--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -196,10 +196,9 @@ class PythonClientBackend(CodeBackend):
                 extra_request_args = [('download_path',
                                        'str',
                                        'Path on local machine to save file.')]
-            if response_binary_body:
+            if response_binary_body and not download_to_file:
                 extra_return_arg = ':class:`requests.models.Response`'
-                if not download_to_file:
-                    footer = DOCSTRING_CLOSE_RESPONSE
+                footer = DOCSTRING_CLOSE_RESPONSE
 
             if route.doc:
                 func_docstring = self.process_doc(route.doc, self._docf)


### PR DESCRIPTION
Addresses incorrect autogenerated docs in https://github.com/dropbox/dropbox-sdk-python/pull/132