### PR TITLE
Revert "Add a flag to emit typescript fields in camel case."

### DIFF
--- a/stone/backends/tsd_helpers.py
+++ b/stone/backends/tsd_helpers.py
@@ -40,17 +40,6 @@ _base_type_table = {
 }
 
 
-def fmt_name_case(name, use_camel_case):
-    # type: (str, bool) -> str
-    """
-    Camel case for variable names is the preferred style in typescript.
-    To keep generated code backwards compatible, camel casing is only enabled behind a flag.
-    """
-    if use_camel_case:
-        return fmt_camel(name)
-    return name
-
-
 def fmt_error_type(data_type, inside_namespace=None):
     """
     Converts the error type into a TypeScript type.
@@ -58,7 +47,6 @@ def fmt_error_type(data_type, inside_namespace=None):
     occurs in, or None if this parameter is not relevant.
     """
     return 'Error<%s>' % fmt_type(data_type, inside_namespace)
-
 
 def fmt_type_name(data_type, inside_namespace=None):
     """
@@ -77,7 +65,6 @@ def fmt_type_name(data_type, inside_namespace=None):
             fmted_type += '<' + fmt_type(data_type.data_type, inside_namespace) + '>'
         return fmted_type
 
-
 def fmt_polymorphic_type_reference(data_type, inside_namespace=None):
     """
     Produces a TypeScript type name for the meta-type that refers to the given
@@ -89,7 +76,6 @@ def fmt_polymorphic_type_reference(data_type, inside_namespace=None):
     #       can defer emitting these types until the end, and emit them in a
     #       nested namespace (e.g., files.references.MetadataReference).
     return fmt_type_name(data_type, inside_namespace) + "Reference"
-
 
 def fmt_type(data_type, inside_namespace=None):
     """
@@ -109,21 +95,17 @@ def fmt_type(data_type, inside_namespace=None):
     else:
         return fmt_type_name(data_type, inside_namespace)
 
-
 def fmt_union(type_strings):
     """
     Returns a union type of the given types.
     """
     return '|'.join(type_strings) if len(type_strings) > 1 else type_strings[0]
 
-
 def fmt_func(name):
     return fmt_camel(name)
 
-
 def fmt_var(name):
     return fmt_camel(name)
-
 
 def fmt_tag(cur_namespace, tag, val):
     """
@@ -148,7 +130,6 @@ def fmt_tag(cur_namespace, tag, val):
         return val
     else:
         raise RuntimeError('Unknown doc ref tag %r' % tag)
-
 
 def generate_imports_for_referenced_namespaces(backend, namespace):
     # type: (Backend, ApiNamespace) -> None

--- a/stone/backends/tsd_types.py
+++ b/stone/backends/tsd_types.py
@@ -32,7 +32,6 @@ from stone.backends.helpers import (
     fmt_pascal,
 )
 from stone.backends.tsd_helpers import (
-    fmt_name_case,
     fmt_polymorphic_type_reference,
     fmt_tag,
     fmt_type,
@@ -55,16 +54,10 @@ _cmdline_parser.add_argument(
           'all of the emitted types.'),
 )
 _cmdline_parser.add_argument(
-    '--exclude-error-types',
+    '--exclude_error_types',
     default=False,
     action='store_true',
     help='If true, the output will exclude the interface for Error type.',
-)
-_cmdline_parser.add_argument(
-    '--use-camel-case',
-    default=False,
-    action='store_true',
-    help='If true, field names will be emitted in camelCase style.',
 )
 _cmdline_parser.add_argument(
     '-e',
@@ -150,13 +143,9 @@ class TSDTypesBackend(CodeBackend):
     # Instance var to denote if one file is output for each namespace.
     split_by_namespace = False
 
-    # To ensure backwards compatibility, although ts style guide recommends camelCase.
-    use_camel_case = False
-
     def generate(self, api):
         extra_args = self._parse_extra_args(api, self.args.extra_arg)
         template = self._read_template()
-        self.use_camel_case = self.args.use_camel_case
         if self.args.filename:
             self._generate_base_namespace_module(api.namespaces.values(), self.args.filename,
                                                  template, extra_args,
@@ -349,7 +338,7 @@ class TSDTypesBackend(CodeBackend):
         """
         namespace = alias_type.namespace
         self.emit('export type %s = %s;' % (fmt_type_name(alias_type, namespace),
-                                            fmt_type_name(alias_type.data_type, namespace)))
+                                     fmt_type_name(alias_type.data_type, namespace)))
         self.emit()
 
     def _generate_struct_type(self, struct_type, indent_spaces, extra_parameters):
@@ -367,8 +356,7 @@ class TSDTypesBackend(CodeBackend):
             for param_name, param_type, param_docstring in extra_parameters:
                 if param_docstring:
                     self._emit_tsdoc_header(param_docstring)
-                self.emit('%s: %s;' % (fmt_name_case(param_name, self.use_camel_case),
-                                       param_type))
+                self.emit('%s: %s;' % (param_name, param_type))
 
             for field in struct_type.fields:
                 doc = field.doc
@@ -384,8 +372,7 @@ class TSDTypesBackend(CodeBackend):
                 if doc:
                     self._emit_tsdoc_header(doc)
                 # Translate nullable types into optional properties.
-                cased_name = fmt_name_case(field.name, self.use_camel_case)
-                field_name = '%s?' % cased_name if optional else cased_name
+                field_name = '%s?' % field.name if optional else field.name
                 self.emit('%s: %s;' % (field_name, field_ts_type))
 
         self.emit('}')
@@ -471,8 +458,7 @@ class TSDTypesBackend(CodeBackend):
                 # it in quotation marks.
                 self.emit("'.tag': '%s';" % variant.name)
                 if is_void_type(variant.data_type) is False:
-                    self.emit("%s: %s;" % (fmt_name_case(variant.name, self.use_camel_case),
-                                           fmt_type(variant.data_type, namespace)))
+                    self.emit("%s: %s;" % (variant.name, fmt_type(variant.data_type, namespace)))
             self.emit('}')
             self.emit()
 

--- a/test/test_tsd_types.py
+++ b/test/test_tsd_types.py
@@ -19,14 +19,10 @@ except ImportError:
     from mock import Mock  # type: ignore
 
 from stone.ir import (
-    Alias,
     ApiNamespace,
     Boolean,
     Struct,
-    StructField,
-    Union,
-    UnionField,
-    Void)
+    StructField)
 from stone.backends.tsd_types import TSDTypesBackend
 from test.backend_test_util import _mock_emit
 
@@ -46,7 +42,7 @@ def _make_backend(target_folder_path, template_path):
 def _make_namespace(ns_name="accounts"):
     # type: (typing.Text) -> ApiNamespace
     ns = ApiNamespace(ns_name)
-    struct = _make_struct('User', 'exists_since', ns)
+    struct = _make_struct('User', 'exists', ns)
     ns.add_data_type(struct)
     return ns
 
@@ -58,13 +54,12 @@ def _make_struct(struct_name, struct_field_name, namespace):
     return struct
 
 
-def _evaluate_namespace(backend, namespace_list, use_camel_case=False):
-    # type: (TSDTypesBackend, typing.List[ApiNamespace], bool) -> typing.Text
+def _evaluate_namespace(backend, namespace_list):
+    # type: (TSDTypesBackend, typing.List[ApiNamespace]) -> typing.Text
 
     emitted = _mock_emit(backend)
     filename = "types.d.ts"
     backend.split_by_namespace = False
-    backend.use_camel_case = use_camel_case
     backend._generate_base_namespace_module(namespace_list=namespace_list,
                                             filename=filename,
                                             extra_args={},
@@ -89,7 +84,7 @@ class TestTSDTypes(unittest.TestCase):
 
         namespace accounts {
           export interface User {
-            exists_since: boolean;
+            exists: boolean;
           }
 
         }
@@ -117,7 +112,7 @@ class TestTSDTypes(unittest.TestCase):
 
         namespace accounts {
           export interface User {
-            exists_since: boolean;
+            exists: boolean;
           }
 
         }
@@ -137,69 +132,15 @@ class TestTSDTypes(unittest.TestCase):
 
         namespace accounts {
           export interface User {
-            exists_since: boolean;
+            exists: boolean;
           }
 
         }
 
         namespace files {
           export interface User {
-            exists_since: boolean;
+            exists: boolean;
           }
-
-        }
-
-
-        """)
-        self.assertEqual(result, expected)
-
-    def test__generate_types_with_camel_casing(self):
-        # type: () -> None
-        backend = _make_backend(target_folder_path="output", template_path="")
-        ns = _make_namespace()
-
-        struct = _make_struct('UserAddress', 'street_number', ns)
-        ns.add_data_type(struct)
-
-        alias = Alias('UserHomeAddress', ns, ast_node=None)
-        alias.set_attributes(doc=None, data_type=struct)
-        ns.add_alias(alias)
-
-        union = Union('UserLocation', ns, ast_node=None, closed=False)
-
-        union.set_attributes(
-            doc=None,
-            fields=[
-                UnionField(
-                    name="zip_code",
-                    doc=None,
-                    data_type=Void(),
-                    ast_node=None
-                )
-            ],
-        )
-        ns.add_data_type(union)
-
-        result = _evaluate_namespace(backend, [ns], use_camel_case=True)
-        expected = textwrap.dedent("""
-        type Timestamp = string;
-
-        namespace accounts {
-          export interface User {
-            existsSince: boolean;
-          }
-
-          export interface UserAddress {
-            streetNumber: boolean;
-          }
-
-          export interface UserLocationZipCode {
-            '.tag': 'zip_code';
-          }
-
-          export type UserLocation = UserLocationZipCode;
-
-          export type UserHomeAddress = UserAddress;
 
         }
 
@@ -248,9 +189,9 @@ namespace ns
 import ns2
 struct A
     "Sample struct doc."
-    client_name String
+    a String
         "Sample field doc."
-    client_id Int64
+    b Int64
 struct B extends ns2.BaseS
     c Bytes
 """
@@ -263,8 +204,8 @@ struct B extends ns2.BaseS
     /**
      * Sample field doc.
      */
-    clientName: string;
-    clientId: number;
+    a: string;
+    b: number;
   }
 
   export interface B extends ns2.BaseS {
@@ -377,8 +318,7 @@ class TestTSDTypesE2E(unittest.TestCase):
              self.stone_output_directory,
              '--',
              self.template_file_name,
-             '--exclude-error-types',
-             '--use-camel-case',
+             '--exclude_error_types',
              '-i=0'],
             stdin=subprocess.PIPE,
             stderr=subprocess.PIPE)
@@ -411,7 +351,6 @@ class TestTSDTypesE2E(unittest.TestCase):
              '--',
              self.template_file_name,
              output_file_name,
-             '--use-camel-case',
              '-i=0'],
             stdin=subprocess.PIPE,
             stderr=subprocess.PIPE)


### PR DESCRIPTION
Undoing the changes which let emitting typescript fields in camel case since it breaks inter-operability across different languages while ser/deserialization.

Eg. Serializing a typescript interface would not be compatible with corresponding type generated for python.

Although, this might be useful when both client side and server side are both javascript but the benefit doesn't seem to outweigh the costs. 

This reverts commit 9f66386151dbee4808b2c25edd5afdca99c681ca.