### PR TITLE
Use more friendly name for unexpected booleans

### DIFF
--- a/stone/backends/python_rsrc/stone_validators.py
+++ b/stone/backends/python_rsrc/stone_validators.py
@@ -74,7 +74,10 @@ class ValidationError(Exception):
 def generic_type_name(v):
     """Return a descriptive type name that isn't Python specific. For example,
     an int value will return 'integer' rather than 'int'."""
-    if isinstance(v, numbers.Integral):
+    if isinstance(v, bool):
+        # Must come before any numbers checks since booleans are integers too
+        return 'boolean'
+    elif isinstance(v, numbers.Integral):
         # Must come before real numbers check since integrals are reals too
         return 'integer'
     elif isinstance(v, numbers.Real):


### PR DESCRIPTION
When a field receives a boolean but expects another type, the Python
validator will try to show a user-friendly name. While `bool` is a
subclass of `int`, telling the end user that an integer was received can
lead to confusion, especially if they don't know this fact. By
explicitly checking if a value is a boolean before checking for numeric
types, `generic_type_name` can return a more explicit type name.

This will add an `isinstance` check that checks for booleans before
checking for numeric types. The check is being added before the other
type checks so that it isn't captured by the check for
`numbers.Integral`.