### PR TITLE
Change python_type_stubs generator to use `bv` instead of `stone_validators` (oops!)

### DIFF
--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -161,7 +161,7 @@ class PythonTypeStubsBackend(CodeBackend):
     def _generate_validator_for(self, data_type):
         # type: (DataType) -> None
         cls_name = class_name_for_data_type(data_type)
-        self.emit("{}_validator = ...  # type: stone_validators.Validator".format(
+        self.emit("{}_validator: bv.Validator = ...".format(
             cls_name
         ))
 
@@ -377,7 +377,7 @@ class PythonTypeStubsBackend(CodeBackend):
         for route in namespace.routes:
             var_name = fmt_func(route.name)
             self.emit(
-                "{var_name} = ...  # type: bb.Route".format(
+                "{var_name}: bb.Route = ...".format(
                     var_name=var_name
                 )
             )

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -237,8 +237,8 @@ class TestPythonTypeStubs(unittest.TestCase):
 
                 @f1.deleter
                 def f1(self) -> None: ...
-            
-            Struct1_validator = ...  # type: stone_validators.Validator
+
+            Struct1_validator: bv.Validator = ...
 
             class Struct2(object):
                 def __init__(self,
@@ -275,7 +275,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 @f4.deleter
                 def f4(self) -> None: ...
 
-            Struct2_validator = ...  # type: stone_validators.Validator
+            Struct2_validator: bv.Validator = ...
 
 
             from typing import (
@@ -318,7 +318,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 @nullable_list.deleter
                 def nullable_list(self) -> None: ...
 
-            NestedTypes_validator = ...  # type: stone_validators.Validator
+            NestedTypes_validator: bv.Validator = ...
 
 
             from typing import (
@@ -343,7 +343,7 @@ class TestPythonTypeStubs(unittest.TestCase):
 
                 def is_last(self) -> bool: ...
 
-            Union_validator = ...  # type: stone_validators.Validator
+            Union_validator: bv.Validator = ...
 
             class Shape(bb.Union):
                 point = ...  # type: Shape
@@ -357,8 +357,8 @@ class TestPythonTypeStubs(unittest.TestCase):
 
                 def get_circle(self) -> float: ...
 
-            Shape_validator = ...  # type: stone_validators.Validator
-            
+            Shape_validator: bv.Validator = ...
+
             """).format(headers=_headers)
         self.assertEqual(result, expected)
 
@@ -371,8 +371,8 @@ class TestPythonTypeStubs(unittest.TestCase):
 
             class EmptyUnion(bb.Union):
                 pass
-                
-            EmptyUnion_validator = ...  # type: stone_validators.Validator
+
+            EmptyUnion_validator: bv.Validator = ...
 
             """).format(headers=_headers)
         self.assertEqual(result, expected)
@@ -384,8 +384,8 @@ class TestPythonTypeStubs(unittest.TestCase):
         expected = textwrap.dedent("""\
             {headers}
 
-            route_one = ...  # type: bb.Route
-            route_two = ...  # type: bb.Route
+            route_one: bb.Route = ...
+            route_two: bb.Route = ...
 
             """).format(headers=_headers)
         self.assertEqual(result, expected)
@@ -410,7 +410,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 @f1.deleter
                 def f1(self) -> None: ...
 
-            Struct1_validator = ...  # type: stone_validators.Validator
+            Struct1_validator: bv.Validator = ...
 
             AliasToStruct1 = Struct1
             """).format(headers=_headers)


### PR DESCRIPTION
﻿a) I was previously annotating as `stone_validators` - but the import actually names them `stone_validators as bv`.

b) I changed the routes and validators to use the [PEP 526](https://www.python.org/dev/peps/pep-0526/)-style variable annotation. Per ilevkivskyi on mypy channel at dropbox's slack, this is the preferred style of all stubs.

c) i have confirmed that this works with dropbox's server repo (having, now figured out that `update_stone` script exists.)

d) I assume the `bv`, `bb` verbiage is leftover from when Stone was Babel - should I change it? 