### PR TITLE
python_type_stubs generator: use typing.Text instead of str

### DIFF
--- a/stone/backends/python_type_mapping.py
+++ b/stone/backends/python_type_mapping.py
@@ -21,6 +21,7 @@ from stone.ir import (
     is_void_type,
 )
 from stone.backends.python_helpers import class_name_for_data_type
+from stone.ir.data_types import String
 from stone.typing_hacks import cast
 
 MYPY = False
@@ -29,14 +30,17 @@ if MYPY:
     DataTypeCls = typing.Type[DataType]
 
     # Unfortunately these are codependent, so I'll weakly type the Dict in Callback
-    Callback = typing.Callable[[ApiNamespace, DataType, typing.Dict[typing.Any, typing.Any]], str]
+    Callback = typing.Callable[
+        [ApiNamespace, DataType, typing.Dict[typing.Any, typing.Any]],
+        typing.Text
+    ]
     OverrideDefaultTypesDict = typing.Dict[DataTypeCls, Callback]
 else:
     OverrideDefaultTypesDict = "OverrideDefaultTypesDict"
 
 
 def map_stone_type_to_python_type(ns, data_type, override_dict=None):
-    # type: (ApiNamespace, DataType, typing.Optional[OverrideDefaultTypesDict]) -> str
+    # type: (ApiNamespace, DataType, typing.Optional[OverrideDefaultTypesDict]) -> typing.Text
     """
     Args:
         override_dict: lets you override the default behavior for a given type by hooking into
@@ -45,6 +49,9 @@ def map_stone_type_to_python_type(ns, data_type, override_dict=None):
     override_dict = override_dict or {}
 
     if is_string_type(data_type):
+        string_override = override_dict.get(String, None)
+        if string_override:
+            return string_override(ns, data_type, override_dict)
         return 'str'
     elif is_bytes_type(data_type):
         return 'bytes'

--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import textwrap
 from contextlib import contextmanager
 
+from stone.ir.data_types import String
 from stone.typing_hacks import cast
 _MYPY = False
 if _MYPY:
@@ -326,45 +327,53 @@ class PythonTypeStubsBackend(CodeBackend):
         we need to potentially import some things.
         """
         def upon_encountering_list(ns, data_type, override_dict):
-            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> str
+            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> typing.Text
             self.import_tracker._register_typing_import("List")
-            return str("List[{}]").format(
+            return "List[{}]".format(
                 map_stone_type_to_python_type(ns, data_type, override_dict)
             )
 
         def upon_encountering_map(ns, map_data_type, override_dict):
-            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> str
+            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> typing.Text
             map_type = cast(Map, map_data_type)
             self.import_tracker._register_typing_import("Dict")
-            return str("Dict[{}, {}]").format(
+            return "Dict[{}, {}]".format(
                 map_stone_type_to_python_type(ns, map_type.key_data_type, override_dict),
                 map_stone_type_to_python_type(ns, map_type.value_data_type, override_dict)
             )
 
         def upon_encountering_nullable(ns, data_type, override_dict):
-            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> str
+            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> typing.Text
             self.import_tracker._register_typing_import("Optional")
-            return str("Optional[{}]").format(
+            return "Optional[{}]".format(
                 map_stone_type_to_python_type(ns, data_type, override_dict)
             )
 
         def upon_encountering_timestamp(
                 ns, data_type, override_dict
         ):  # pylint: disable=unused-argument
-            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> str
+            # type: (ApiNamespace, DataType, OverrideDefaultTypesDict) -> typing.Text
             self.import_tracker._register_adhoc_import("import datetime")
             return map_stone_type_to_python_type(ns, data_type)
+
+        def upon_encountering_string(
+            ns, data_type, override_dict
+        ):  # pylint: disable=unused-argument
+            # type: (...) -> typing.Text
+            self.import_tracker._register_typing_import("Text")
+            return "Text"
 
         callback_dict = {
             List: upon_encountering_list,
             Map: upon_encountering_map,
             Nullable: upon_encountering_nullable,
             Timestamp: upon_encountering_timestamp,
+            String: upon_encountering_string,
         }  # type: OverrideDefaultTypesDict
         return callback_dict
 
     def map_stone_type_to_pep484_type(self, ns, data_type):
-        # type: (ApiNamespace, DataType) -> str
+        # type: (ApiNamespace, DataType) -> typing.Text
         assert self._pep_484_type_mapping_callbacks
         return map_stone_type_to_python_type(ns, data_type,
                                              override_dict=self._pep_484_type_mapping_callbacks)

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -206,7 +206,7 @@ class PythonTypesBackend(CodeBackend):
             raise RuntimeError('Unknown doc ref tag %r' % tag)
 
     def _python_type_mapping(self, ns, data_type):
-        # type: (ApiNamespace, DataType) -> str
+        # type: (ApiNamespace, DataType) -> typing.Text
         """Map Stone data types to their most natural equivalent in Python
         for documentation purposes."""
         return map_stone_type_to_python_type(ns, data_type)

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -244,7 +244,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def __init__(self,
                              f2: List[long] = ...,
                              f3: datetime.datetime = ...,
-                             f4: Dict[str, long] = ...) -> None: ...
+                             f4: Dict[Text, long] = ...) -> None: ...
 
                 @property
                 def f2(self) -> List[long]: ...
@@ -267,10 +267,10 @@ class TestPythonTypeStubs(unittest.TestCase):
 
 
                 @property
-                def f4(self) -> Dict[str, long]: ...
+                def f4(self) -> Dict[Text, long]: ...
 
                 @f4.setter
-                def f4(self, val: Dict[str, long]) -> None: ...
+                def f4(self, val: Dict[Text, long]) -> None: ...
 
                 @f4.deleter
                 def f4(self) -> None: ...
@@ -281,6 +281,7 @@ class TestPythonTypeStubs(unittest.TestCase):
             from typing import (
                 Dict,
                 List,
+                Text,
             )
 
             import datetime


### PR DESCRIPTION
## What is typing.Text?
It's a type that means
if py2: means `unicode`
if py3: means `str` (which is a unicode object)

I was previously outputting just `str` which meant this behavior was wrong from py2 (in py2 world it expected non-unicode, ascii strings).

## Testing
There are unit tests done on Stone itself, and I confirmed this change is compatible with the current version of Dropbox's server repo after an `./update-stone` + `//tools:stone` + `mypy-run`

## Motivation for change
Existing behavior was a bug on my part.
Colin posted in Dropbox's api-platform slack that it was broken