### PR TITLE
PYI type stubs: added _validator for aliases

### DIFF
--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -253,6 +253,7 @@ class PythonTypeStubsBackend(CodeBackend):
             self.emit('{} = {}'.format(
                 alias.name,
                 class_name_for_data_type(alias.data_type, namespace)))
+            self._generate_validator_for(alias)
 
     def _class_declaration_for_type(self, ns, data_type):
         # type: (ApiNamespace, typing.Union[Struct, Union]) -> typing.Text

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -414,5 +414,6 @@ class TestPythonTypeStubs(unittest.TestCase):
             Struct1_validator: bv.Validator = ...
 
             AliasToStruct1 = Struct1
+            AliasToStruct1_validator: bv.Validator = ...
             """).format(headers=_headers)
         self.assertEqual(result, expected)


### PR DESCRIPTION
Aliases apparently have their own validators. Oops!

I believe this is the final missing piece before feature-parity between the true .py source and .pyi type stubs.