### PR TITLE
Generate validators for all aliases, not just user-defined aliases.

### DIFF
--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -246,6 +246,8 @@ class PythonTypeStubsBackend(CodeBackend):
 
     def _generate_alias_definition(self, namespace, alias):
         # type: (ApiNamespace, Alias) -> None
+        self._generate_validator_for(alias)
+
         unwrapped_dt, _ = unwrap_aliases(alias)
         if is_user_defined_type(unwrapped_dt):
             # If the alias is to a composite type, we want to alias the
@@ -253,7 +255,6 @@ class PythonTypeStubsBackend(CodeBackend):
             self.emit('{} = {}'.format(
                 alias.name,
                 class_name_for_data_type(alias.data_type, namespace)))
-            self._generate_validator_for(alias)
 
     def _class_declaration_for_type(self, ns, data_type):
         # type: (ApiNamespace, typing.Union[Struct, Union]) -> typing.Text

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -56,6 +56,11 @@ def _make_namespace_with_alias():
     alias.set_attributes(doc=None, data_type=struct1)
     ns.add_alias(alias)
 
+    str_type = String(min_length=3)
+    str_alias = Alias(name='NotUserDefinedAlias', namespace=ns, ast_node=None)
+    str_alias.set_attributes(doc=None, data_type=str_type)
+    ns.add_alias(str_alias)
+
     return ns
 
 def _make_namespace_with_many_structs():
@@ -413,7 +418,8 @@ class TestPythonTypeStubs(unittest.TestCase):
 
             Struct1_validator: bv.Validator = ...
 
-            AliasToStruct1 = Struct1
             AliasToStruct1_validator: bv.Validator = ...
+            AliasToStruct1 = Struct1
+            NotUserDefinedAlias_validator: bv.Validator = ...
             """).format(headers=_headers)
         self.assertEqual(result, expected)


### PR DESCRIPTION
last one guys, I swear.

Previously we weren't generating a validator in the PYI generator if I said
```
alias SomethingId = String(pattern="whatever")
```

This more closely follows the Python (non-pyi) generator.
https://github.com/dropbox/stone/blob/master/stone/backends/python_types.py#L155