### PR TITLE
Fix doc ref bug in Stone frontend

### DIFF
--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -954,7 +954,7 @@ class IRGenerator(object):
             resolved_data_type_args = self._resolve_args(env, type_ref.args)
             data_type = self._instantiate_data_type(
                 obj, resolved_data_type_args, (type_ref.lineno, type_ref.path))
-        elif isinstance(obj, ApiRoute):
+        elif isinstance(obj, ApiRoutesByVersion):
             raise InvalidSpec('A route cannot be referenced here.',
                               *loc)
         elif type_ref.args[0] or type_ref.args[1]:

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -1210,7 +1210,7 @@ class IRGenerator(object):
                             'Bad doc reference to field %s of '
                             'unknown type %s.' % (field_name, quote(type_name)),
                             *loc)
-                    elif isinstance(env[type_name], ApiRoute):
+                    elif isinstance(env[type_name], ApiRoutesByVersion):
                         raise InvalidSpec(
                             'Bad doc reference to field %s of route %s.' %
                             (quote(field_name), quote(type_name)),

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -1049,7 +1049,7 @@ class IRGenerator(object):
             item (AstRouteDef): Raw route definition from the parser.
 
         Returns:
-            stone.api.ApiRoute: A fully-defined route.
+            stone.api.ApiRoutesByVersion: A group of fully-defined routes indexed by versions.
         """
         if item.name in env:
             if isinstance(env[item.name], ApiRoutesByVersion):
@@ -1252,7 +1252,7 @@ class IRGenerator(object):
                     raise InvalidSpec(
                         'Unknown doc reference to route %s.' % quote(val),
                         *loc)
-                elif not isinstance(env_to_check[val], ApiRoute):
+                elif not isinstance(env_to_check[val], ApiRoutesByVersion):
                     raise InvalidSpec(
                         'Doc reference to type %s is not a route.' %
                         quote(val), *loc)

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -1071,6 +1071,7 @@ class TestStone(unittest.TestCase):
             specs_to_ir([('test.stone', text)])
         self.assertEqual("A route cannot be referenced here.", cm.exception.msg)
         self.assertEqual(cm.exception.lineno, 5)
+        self.assertEqual(cm.exception.path, 'test.stone')
 
         # Test aliasing from another namespace
         text1 = textwrap.dedent("""\
@@ -2180,6 +2181,20 @@ class TestStone(unittest.TestCase):
                     "field doc ref :route:`test_route`"
             """)
         specs_to_ir([('test.stone', text)])
+
+        # Test referencing an undefined route
+        text = textwrap.dedent("""\
+            namespace test
+    
+            struct T
+                "type doc ref :route:`test_route`"
+                f String
+            """)
+        with self.assertRaises(InvalidSpec) as cm:
+            specs_to_ir([('test.stone', text)])
+        self.assertEqual("Unknown doc reference to route 'test_route'.", cm.exception.msg)
+        self.assertEqual(cm.exception.lineno, 4)
+        self.assertEqual(cm.exception.path, 'test.stone')
 
     def test_namespace(self):
         # Test that namespace docstrings are combined

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -1059,6 +1059,19 @@ class TestStone(unittest.TestCase):
         self.assertIn('Attributes cannot be specified for instantiated type',
                       cm.exception.msg)
 
+        # Test aliasing to route
+        text = textwrap.dedent("""\
+            namespace test
+
+            route test_route(Void, Void, Void)
+
+            alias S = test_route
+            """)
+        with self.assertRaises(InvalidSpec) as cm:
+            specs_to_ir([('test.stone', text)])
+        self.assertEqual("A route cannot be referenced here.", cm.exception.msg)
+        self.assertEqual(cm.exception.lineno, 5)
+
         # Test aliasing from another namespace
         text1 = textwrap.dedent("""\
             namespace test1

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -2196,6 +2196,22 @@ class TestStone(unittest.TestCase):
         self.assertEqual(cm.exception.lineno, 4)
         self.assertEqual(cm.exception.path, 'test.stone')
 
+        # Test referencing a field of a route
+        text = textwrap.dedent("""\
+            namespace test
+            
+            route test_route(Void, Void, Void)
+            
+            struct T
+                "type doc ref :field:`test_route.g`"
+                f String
+            """)
+        with self.assertRaises(InvalidSpec) as cm:
+            specs_to_ir([('test.stone', text)])
+        self.assertEqual("Bad doc reference to field 'g' of route 'test_route'.", cm.exception.msg)
+        self.assertEqual(cm.exception.lineno, 6)
+        self.assertEqual(cm.exception.path, 'test.stone')
+
     def test_namespace(self):
         # Test that namespace docstrings are combined
         ns1_text = textwrap.dedent("""\

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -692,8 +692,7 @@ class TestStone(unittest.TestCase):
             """)
         with self.assertRaises(InvalidSpec) as cm:
             specs_to_ir([('test.stone', text)])
-        self.assertEqual("Version number should be a positive integer.",
-                         cm.exception.msg)
+        self.assertEqual("Version number should be a positive integer.", cm.exception.msg)
         self.assertEqual(cm.exception.lineno, 3)
 
         # Test using negative integer as version number
@@ -704,8 +703,7 @@ class TestStone(unittest.TestCase):
             """)
         with self.assertRaises(InvalidSpec) as cm:
             specs_to_ir([('test.stone', text)])
-        self.assertEqual("Version number should be a positive integer.",
-                         cm.exception.msg)
+        self.assertEqual("Version number should be a positive integer.", cm.exception.msg)
         self.assertEqual(cm.exception.lineno, 3)
 
         # Test deprecating by a route at an undefined version
@@ -2130,7 +2128,7 @@ class TestStone(unittest.TestCase):
             cm.exception.msg)
 
     def test_doc_refs(self):
-        # Test union doc referencing field
+        # Test union doc referencing a field
         text = textwrap.dedent("""\
             namespace test
 
@@ -2141,7 +2139,7 @@ class TestStone(unittest.TestCase):
             """)
         specs_to_ir([('test.stone', text)])
 
-        # Test union field doc referencing other field
+        # Test union field doc referencing another field
         text = textwrap.dedent("""\
             namespace test
 
@@ -2149,6 +2147,24 @@ class TestStone(unittest.TestCase):
                 a
                     ":field:`b`"
                 b
+            """)
+        specs_to_ir([('test.stone', text)])
+
+        # Test docs referencing a route
+        text = textwrap.dedent("""\
+            namespace test
+            
+            route test_route(Void, Void, Void)
+            
+            struct T
+                "type doc ref :route:`test_route`"
+                f String
+                    "field doc ref :route:`test_route`"
+            
+            union U
+                "type doc ref :route:`test_route`"
+                f String
+                    "field doc ref :route:`test_route`"
             """)
         specs_to_ir([('test.stone', text)])
 

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -2167,14 +2167,14 @@ class TestStone(unittest.TestCase):
         # Test docs referencing a route
         text = textwrap.dedent("""\
             namespace test
-            
+
             route test_route(Void, Void, Void)
-            
+
             struct T
                 "type doc ref :route:`test_route`"
                 f String
                     "field doc ref :route:`test_route`"
-            
+
             union U
                 "type doc ref :route:`test_route`"
                 f String
@@ -2185,7 +2185,7 @@ class TestStone(unittest.TestCase):
         # Test referencing an undefined route
         text = textwrap.dedent("""\
             namespace test
-    
+
             struct T
                 "type doc ref :route:`test_route`"
                 f String
@@ -2199,9 +2199,9 @@ class TestStone(unittest.TestCase):
         # Test referencing a field of a route
         text = textwrap.dedent("""\
             namespace test
-            
+
             route test_route(Void, Void, Void)
-            
+
             struct T
                 "type doc ref :field:`test_route.g`"
                 f String


### PR DESCRIPTION
* Replaced occurrences of `ApiRoute` with `ApiRoutesByVersion`.
* Added more test coverage.