### PR TITLE
Add missing comma between `-z` and `--style-to-request`.

### DIFF
--- a/stone/backends/obj_c_client.py
+++ b/stone/backends/obj_c_client.py
@@ -84,7 +84,7 @@ _cmdline_parser.add_argument(
     type=str,
     help='The client-side route arguments to append to each route by style type.', )
 _cmdline_parser.add_argument(
-    '-z'
+    '-z',
     '--style-to-request',
     required=True,
     type=str,
@@ -285,7 +285,7 @@ class ObjCBackend(ObjCBaseBackend):
                 with self.block_init():
                     self.emit('_client = client;')
             self.emit()
-            style_to_request = json.loads(self.args.z__style_to_request)
+            style_to_request = json.loads(self.args.style_to_request)
 
             for route in namespace.routes:
                 if (route.attrs.get('auth') != self.args.auth_type
@@ -416,7 +416,7 @@ class ObjCBackend(ObjCBaseBackend):
             self.emit('{};'.format(init_signature))
             self.emit()
 
-            style_to_request = json.loads(self.args.z__style_to_request)
+            style_to_request = json.loads(self.args.style_to_request)
 
             for route in namespace.routes:
                 if (route.attrs.get('auth') != self.args.auth_type


### PR DESCRIPTION
I'm just experimenting with Stone so I'm not sure, but this looked like a bug or inconsistency between the Objective-C and Swift backends.