### PR TITLE
Add multiline support for map types in examples

### DIFF
--- a/docs/lang_ref.rst
+++ b/docs/lang_ref.rst
@@ -313,6 +313,33 @@ Maps are expressed with curly braces::
         example default
             similar_colors = {"blue": ["aqua", "azure"], "red": ["crimson"], "green": []}
 
+Map examples can also be multiline (Be mindful of indentation rules)::
+
+    struct SimpleDigits
+        digit_mapping Map(String, Int32)
+
+        example default
+            digit_mapping = # Mapping starts on line below
+                {
+                    "one": 1,
+                    "two": 2
+                }
+
+    struct Digits
+        digit_mapping Map(String, Map(String, Int32))
+
+        example default
+            digit_mapping = { # Mapping starts on same line as example
+                "one": {
+                    "one": 11,
+                    "two": 12
+                },
+                "two": {
+                    "one": 21,
+                    "two": 22
+                }
+            }
+
 Union
 =====
 

--- a/stone/frontend/parser.py
+++ b/stone/frontend/parser.py
@@ -732,6 +732,11 @@ class ParserFactory(object):
             p[0] = AstExampleField(
                 self.path, p.lineno(1), p.lexpos(1), p[1], p[3])
 
+    def p_example_multiline(self, p):
+        """example_field : ID EQ NL INDENT ex_map NL DEDENT"""
+        p[0] = AstExampleField(
+            self.path, p.lineno(1), p.lexpos(1), p[1], p[5])
+
     def p_example_field_ref(self, p):
         'example_field : ID EQ ID NL'
         p[0] = AstExampleField(self.path, p.lineno(1), p.lexpos(1),
@@ -781,6 +786,10 @@ class ParserFactory(object):
                   | LBRACE empty RBRACE"""
         p[0] = p[2] or {}
 
+    def p_ex_map_multiline(self, p):
+        """ex_map : LBRACE NL INDENT ex_map_pairs NL DEDENT RBRACE"""
+        p[0] = p[4] or {}
+
     def p_ex_map_elem_primitive(self, p):
         """ex_map_elem : primitive"""
         p[0] = None if p[1] == NullToken else p[1]
@@ -811,6 +820,11 @@ class ParserFactory(object):
         """ex_map_pairs : ex_map_pairs COMMA ex_map_pair"""
         p[0] = p[1]
         p[0].update(p[3])
+
+    def p_ex_map_pairs_multiline(self, p):
+        """ex_map_pairs : ex_map_pairs COMMA NL ex_map_pair"""
+        p[0] = p[1]
+        p[0].update(p[4])
 
     # --------------------------------------------------------------
 

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -3626,6 +3626,81 @@ class TestStone(unittest.TestCase):
         with self.assertRaises(InvalidSpec):
             specs_to_ir([('test.stone', text)])
 
+        # test multiline docstrings
+        text = textwrap.dedent("""\
+        namespace test
+
+        struct S
+            m Map(String, Int32)
+
+            example default
+                m = {
+                    "one": 1, "two": 2
+                }
+        """)
+
+        api = specs_to_ir([('test.stone', text)])
+        s = api.namespaces['test'].data_type_by_name['S']
+        self.assertIsInstance(s.get_examples()['default'].value, dict)
+
+        text = textwrap.dedent("""\
+        namespace test
+
+        struct S
+            m Map(String, Int32)
+
+            example default
+                m =
+                    {
+                        "one": 1, "two": 2
+                    }
+        """)
+
+        api = specs_to_ir([('test.stone', text)])
+        s = api.namespaces['test'].data_type_by_name['S']
+        self.assertIsInstance(s.get_examples()['default'].value, dict)
+
+        text = textwrap.dedent("""\
+                namespace test
+
+                struct S
+                    m Map(String, Int32)
+
+                    example default
+                        m =
+                            {
+                                "one": 1,
+                                "two": 2
+                            }
+                """)
+
+        api = specs_to_ir([('test.stone', text)])
+        s = api.namespaces['test'].data_type_by_name['S']
+        self.assertIsInstance(s.get_examples()['default'].value, dict)
+
+        text = textwrap.dedent("""\
+        namespace test
+
+        struct S
+            m Map(String, Map(String, Int32))
+
+            example default
+                m = {
+                    "one": {
+                        "one": 11,
+                        "two": 12
+                    },
+                    "two": {
+                        "one": 21,
+                        "two": 22
+                    }
+                }
+        """)
+
+        api = specs_to_ir([('test.stone', text)])
+        s = api.namespaces['test'].data_type_by_name['S']
+        self.assertIsInstance(s.get_examples()['default'].value, dict)
+
     def test_name_conflicts(self):
         # Test name conflict in same file
         text = textwrap.dedent("""\


### PR DESCRIPTION
Subject says it all.  examples now support multiline maps of the form:

```
example ex
    map = {
        "one": 1,
        "two": 2
    }
```
and
```
example ex
    map = 
        {
            "one": 1,
            "two": 2
        }
```
