### PR TITLE
Include string that failed to decode in error

### DIFF
--- a/stone/backends/python_rsrc/stone_validators.py
+++ b/stone/backends/python_rsrc/stone_validators.py
@@ -306,7 +306,7 @@ class String(Primitive):
             try:
                 val = val.decode('utf-8')
             except UnicodeDecodeError:
-                raise ValidationError("'%s' was not valid utf-8")
+                raise ValidationError("'%s' was not valid utf-8" % val)
 
         if self.max_length is not None and len(val) > self.max_length:
             raise ValidationError("'%s' must be at most %d characters, got %d"


### PR DESCRIPTION
The `ValidationError` message already includes a placeholder for the
string that failed to decode to unicode. This will include the value for
the placeholder.