### PR TITLE
Kellyroach/fix objc warnings

### DIFF
--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -976,7 +976,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                         self.emit('jsonDict[@"{}"] = {};'.format(
                             field.name, serialize_call))
                 else:
-                    with self.block('if ({})'.format(input_value)):
+                    with self.block('if ({} != nil)'.format(input_value)):
                         self.emit('jsonDict[@"{}"] = {};'.format(
                             field.name, serialize_call))
             self.emit()

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -826,7 +826,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
             enum_field_name = fmt_enum_name(field.name, data_type)
             self.emit('case {}:'.format(enum_field_name))
         if nullable:
-            with self.block('if (self.{})'.format(fmt_var(field.name))):
+            with self.block('if (self.{} != nil)'.format(fmt_var(field.name))):
                 self._generate_equality_check(data_type, field, other_obj_name)
         else:
             self._generate_equality_check(data_type, field, other_obj_name)


### PR DESCRIPTION
Dropbox stone repo's Python code is used by the Dropbox dropbox-sdk-obj-c repo's generate_base_client.py script to autogenerate Objective-C code in
Source/ObjectiveDropboxOfficial/Shared/Generated/ApiObjects/*.m+*.h
file locations.  From there, a user can Xcode build targets in either
ObjectiveDropboxOfficial.xcodeproj or TestObjectiveDropbox.xcworkspace .
However, the Dropbox autogenerated code is not quite perfect in Xcode Analyze's
eyes.  Xcode Analyze gets 49 blue analyzer results analyzing TestObjectiveDropbox .
These "results" are a concern because these static lint analysis issues represent
potential real issues in the Objective-C code.  It's preferable to get a clean bill of
health from Xcode Analyze.

Our pull request does just that by committing 3 relatively lightweight changes
to stone's obj_c_types.py .