### PR TITLE
Use static NSDateFormatter to improve performance

### DIFF
--- a/stone/backends/obj_c_rsrc/DBStoneSerializers.m
+++ b/stone/backends/obj_c_rsrc/DBStoneSerializers.m
@@ -12,10 +12,14 @@
     if (value == nil) {
         [DBStoneValidators raiseIllegalStateErrorWithMessage:@"Value must not be `nil`"];
     }
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-    [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-    [formatter setDateFormat:[self convertFormat:dateFormat]];
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+        [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+        [formatter setDateFormat:[self convertFormat:dateFormat]];
+    });
 
     return [formatter stringFromDate:value];
 }
@@ -25,10 +29,14 @@
     if (value == nil) {
         [DBStoneValidators raiseIllegalStateErrorWithMessage:@"Value must not be `nil`"];
     }
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-    [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-    [formatter setDateFormat:[self convertFormat:dateFormat]];
+    static NSDateFormatter *formatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+        [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+        [formatter setDateFormat:[self convertFormat:dateFormat]];
+    });
 
     return [formatter dateFromString:value];
 }


### PR DESCRIPTION
This small change has significant performance consequences: in Dropbox for iOS, it reduces main thread CPU time from 12s to 1.5s and overall CPU time inside `NSDateFormatter` from 60% to 20% of all CPU time when processing file metadata for 17k photos.