### PR TITLE
support multiple auth modes in python SDK generation backend for stone

### DIFF
--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -180,7 +180,7 @@ class PythonClientBackend(CodeBackend):
         for route in namespace.routes:
             route_auth_modes = [mode.strip().lower() for mode in route.attrs.get('auth').split(',')]
             for base_auth_type in self.supported_auth_types:
-                if base_auth_type in route_auth_modes or (base_auth_type == 'user' and 'noauth' in route_auth_modes):
+                if base_auth_type in route_auth_modes:
                     self._generate_route_helper(namespace, route)
                     if route.attrs.get('style') == 'download':
                         self._generate_route_helper(namespace, route, True)

--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -181,7 +181,7 @@ class PythonClientBackend(CodeBackend):
         for route in namespace.routes:
             route_auth_attr = route.attrs.get('auth')
             if route_auth_attr is None or self.supported_auth_types is None:
-               continue
+                continue
             route_auth_modes = [mode.strip().lower() for mode in route_auth_attr.split(',')]
             for base_auth_type in self.supported_auth_types:
                 if base_auth_type in route_auth_modes:

--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -171,6 +171,7 @@ class PythonClientBackend(CodeBackend):
         """
         Generates Python methods that correspond to routes in the namespace.
         """
+        print("----------> in _generate_routes()")
 
         # Hack: needed for _docf()
         self.cur_namespace = namespace
@@ -178,7 +179,11 @@ class PythonClientBackend(CodeBackend):
         check_route_name_conflict(namespace)
 
         for route in namespace.routes:
-            route_auth_modes = [mode.strip().lower() for mode in route.attrs.get('auth').split(',')]
+            print(route.attrs.get('auth'))
+            route_auth_attr = route.attrs.get('auth')
+            if route_auth_attr is None:
+               continue
+            route_auth_modes = [mode.strip().lower() for mode in route_auth_attr.split(',')]
             for base_auth_type in self.supported_auth_types:
                 if base_auth_type in route_auth_modes:
                     self._generate_route_helper(namespace, route)

--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -117,7 +117,6 @@ class PythonClientBackend(CodeBackend):
         The module will contain a base class that will have a method for
         each route across all namespaces.
         """
-        self.supported_auth_types = [auth_type.strip().lower() for auth_type in self.args.auth_type.split(',')]
 
         with self.output_to_relative_path('%s.py' % self.args.module_name):
             self.emit_raw(base)
@@ -171,17 +170,17 @@ class PythonClientBackend(CodeBackend):
         """
         Generates Python methods that correspond to routes in the namespace.
         """
-        print("----------> in _generate_routes()")
 
         # Hack: needed for _docf()
         self.cur_namespace = namespace
+        # list of auth_types supported in this base class.
+        self.supported_auth_types = [auth_type.strip().lower() for auth_type in self.args.auth_type.split(',')]
 
         check_route_name_conflict(namespace)
 
         for route in namespace.routes:
-            print(route.attrs.get('auth'))
             route_auth_attr = route.attrs.get('auth')
-            if route_auth_attr is None:
+            if route_auth_attr is None or self.supported_auth_types is None:
                continue
             route_auth_modes = [mode.strip().lower() for mode in route_auth_attr.split(',')]
             for base_auth_type in self.supported_auth_types:

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -19,7 +19,7 @@ class TestGeneratedPythonClient(unittest.TestCase):
 
         backend = PythonClientBackend(
             target_folder_path='output',
-            args=['-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
+            args=['-w', 'user', '-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
         emitted = _mock_emit(backend)
         backend._generate_routes(ns)
         result = "".join(emitted)

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -30,7 +30,7 @@ class TestGeneratedPythonClient(unittest.TestCase):
         # type: () -> None
 
         route1 = ApiRoute('get_metadata', 1, None)
-        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(), 
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
                               {'auth': 'user'})
         route2 = ApiRoute('get_metadata', 2, None)
         route2.set_attributes(None, None, Void(), Int32(), Void(), {'auth': 'user'})

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -17,11 +17,12 @@ class TestGeneratedPythonClient(unittest.TestCase):
     def _evaluate_namespace(self, ns):
         # type: (ApiNamespace) -> typing.Text
 
+        # supply supported auth modes to the SDK generator using the new syntax
         backend = PythonClientBackend(
             target_folder_path='output',
             args=['-w', 'user', '-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
         emitted = _mock_emit(backend)
-        backend._generate_routes(ns)
+        backend._generate_route_methods({ns})
         result = "".join(emitted)
         return result
 
@@ -29,9 +30,9 @@ class TestGeneratedPythonClient(unittest.TestCase):
         # type: () -> None
 
         route1 = ApiRoute('get_metadata', 1, None)
-        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(), {})
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(), {'auth': 'user'})
         route2 = ApiRoute('get_metadata', 2, None)
-        route2.set_attributes(None, None, Void(), Int32(), Void(), {})
+        route2.set_attributes(None, None, Void(), Int32(), Void(), {'auth': 'user'})
         ns = ApiNamespace('files')
         ns.add_route(route1)
         ns.add_route(route2)
@@ -39,6 +40,9 @@ class TestGeneratedPythonClient(unittest.TestCase):
         result = self._evaluate_namespace(ns)
 
         expected = textwrap.dedent('''\
+            # ------------------------------------------
+            # Routes in files namespace
+
             def files_get_metadata(self):
                 """
                 :meth:`files_get_metadata_v2`

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -164,25 +164,25 @@ class TestGeneratedPythonClient(unittest.TestCase):
     def test_route_with_auth_mode3(self):
             # type: () -> None
 
-            route1 = ApiRoute('get_metadata', 1, None)
-            route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
-                                  {'auth': 'app'})
-            route2 = ApiRoute('get_metadata', 2, None)
-            route2.set_attributes(None, None, Void(), Int32(), Void(),
-                                  {'auth': 'app, team'})
-            ns = ApiNamespace('files')
-            ns.add_route(route1)
-            ns.add_route(route2)
+        route1 = ApiRoute('get_metadata', 1, None)
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
+                             {'auth': 'app'})
+        route2 = ApiRoute('get_metadata', 2, None)
+        route2.set_attributes(None, None, Void(), Int32(), Void(),
+                             {'auth': 'app, team'})
+        ns = ApiNamespace('files')
+        ns.add_route(route1)
+        ns.add_route(route2)
 
-            result = self._evaluate_namespace_with_auth_mode(ns, 'user')
+        result = self._evaluate_namespace_with_auth_mode(ns, 'user')
 
-            expected = textwrap.dedent('''\
-                # ------------------------------------------
-                # Routes in files namespace
+        expected = textwrap.dedent('''\
+            # ------------------------------------------
+            # Routes in files namespace
 
-            ''')
+        ''')
 
-            self.assertEqual(result, expected)
+        self.assertEqual(result, expected)
 
     def test_route_with_version_number_name_conflict(self):
         # type: () -> None

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -19,7 +19,7 @@ class TestGeneratedPythonClient(unittest.TestCase):
 
         backend = PythonClientBackend(
             target_folder_path='output',
-            args=['-w', 'user', '-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
+            args=['-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
         emitted = _mock_emit(backend)
         backend._generate_routes(ns)
         result = "".join(emitted)

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -93,7 +93,7 @@ class TestGeneratedPythonClient(unittest.TestCase):
         ns.add_route(route1)
         ns.add_route(route2)
 
-        result = self._evaluate_namespace_with_auth_mode(ns,'user')
+        result = self._evaluate_namespace_with_auth_mode(ns, 'user')
 
         expected = textwrap.dedent('''\
             # ------------------------------------------
@@ -126,7 +126,7 @@ class TestGeneratedPythonClient(unittest.TestCase):
         ns.add_route(route1)
         ns.add_route(route2)
 
-        result = self._evaluate_namespace_with_auth_mode(ns,'user')
+        result = self._evaluate_namespace_with_auth_mode(ns, 'user')
 
         expected = textwrap.dedent('''\
             # ------------------------------------------

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -30,7 +30,8 @@ class TestGeneratedPythonClient(unittest.TestCase):
         # type: () -> None
 
         route1 = ApiRoute('get_metadata', 1, None)
-        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(), {'auth': 'user'})
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(), 
+                              {'auth': 'user'})
         route2 = ApiRoute('get_metadata', 2, None)
         route2.set_attributes(None, None, Void(), Int32(), Void(), {'auth': 'user'})
         ns = ApiNamespace('files')

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -17,10 +17,21 @@ class TestGeneratedPythonClient(unittest.TestCase):
     def _evaluate_namespace(self, ns):
         # type: (ApiNamespace) -> typing.Text
 
+        backend = PythonClientBackend(
+            target_folder_path='output',
+            args=['-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
+        emitted = _mock_emit(backend)
+        backend._generate_routes(ns)
+        result = "".join(emitted)
+        return result
+
+    def _evaluate_namespace_with_auth_mode(self, ns, auth_mode):
+        # type: (ApiNamespace) -> typing.Text
+
         # supply supported auth modes to the SDK generator using the new syntax
         backend = PythonClientBackend(
             target_folder_path='output',
-            args=['-w', 'user', '-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
+            args=['-w', auth_mode, '-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
         emitted = _mock_emit(backend)
         backend._generate_route_methods({ns})
         result = "".join(emitted)
@@ -30,15 +41,92 @@ class TestGeneratedPythonClient(unittest.TestCase):
         # type: () -> None
 
         route1 = ApiRoute('get_metadata', 1, None)
-        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
-                              {'auth': 'user'})
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(), {})
         route2 = ApiRoute('get_metadata', 2, None)
-        route2.set_attributes(None, None, Void(), Int32(), Void(), {'auth': 'user'})
+        route2.set_attributes(None, None, Void(), Int32(), Void(), {})
         ns = ApiNamespace('files')
         ns.add_route(route1)
         ns.add_route(route2)
 
         result = self._evaluate_namespace(ns)
+
+        expected = textwrap.dedent('''\
+            def files_get_metadata(self):
+                """
+                :meth:`files_get_metadata_v2`
+
+                :rtype: None
+                """
+                arg = None
+                r = self.request(
+                    files.get_metadata,
+                    'files',
+                    arg,
+                    None,
+                )
+                return None
+
+            def files_get_metadata_v2(self):
+                arg = None
+                r = self.request(
+                    files.get_metadata_v2,
+                    'files',
+                    arg,
+                    None,
+                )
+                return r
+
+        ''')
+
+        self.assertEqual(result, expected)
+
+    def test_route_with_auth_mode1(self):
+        # type: () -> None
+
+        route1 = ApiRoute('get_metadata', 1, None)
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
+                              {'auth': 'app'})
+        route2 = ApiRoute('get_metadata', 2, None)
+        route2.set_attributes(None, None, Void(), Int32(), Void(),
+                              {'auth': 'user, app'})
+        ns = ApiNamespace('files')
+        ns.add_route(route1)
+        ns.add_route(route2)
+
+        result = self._evaluate_namespace_with_auth_mode(ns,'user')
+
+        expected = textwrap.dedent('''\
+            # ------------------------------------------
+            # Routes in files namespace
+
+            def files_get_metadata_v2(self):
+                arg = None
+                r = self.request(
+                    files.get_metadata_v2,
+                    'files',
+                    arg,
+                    None,
+                )
+                return r
+
+        ''')
+
+        self.assertEqual(result, expected)
+
+    def test_route_with_auth_mode2(self):
+        # type: () -> None
+
+        route1 = ApiRoute('get_metadata', 1, None)
+        route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
+                              {'auth': 'user'})
+        route2 = ApiRoute('get_metadata', 2, None)
+        route2.set_attributes(None, None, Void(), Int32(), Void(),
+                              {'auth': 'user, app'})
+        ns = ApiNamespace('files')
+        ns.add_route(route1)
+        ns.add_route(route2)
+
+        result = self._evaluate_namespace_with_auth_mode(ns,'user')
 
         expected = textwrap.dedent('''\
             # ------------------------------------------
@@ -72,6 +160,29 @@ class TestGeneratedPythonClient(unittest.TestCase):
         ''')
 
         self.assertEqual(result, expected)
+
+    def test_route_with_auth_mode3(self):
+            # type: () -> None
+
+            route1 = ApiRoute('get_metadata', 1, None)
+            route1.set_attributes(None, ':route:`get_metadata:2`', Void(), Void(), Void(),
+                                  {'auth': 'app'})
+            route2 = ApiRoute('get_metadata', 2, None)
+            route2.set_attributes(None, None, Void(), Int32(), Void(),
+                                  {'auth': 'app, team'})
+            ns = ApiNamespace('files')
+            ns.add_route(route1)
+            ns.add_route(route2)
+
+            result = self._evaluate_namespace_with_auth_mode(ns, 'user')
+
+            expected = textwrap.dedent('''\
+                # ------------------------------------------
+                # Routes in files namespace
+
+            ''')
+
+            self.assertEqual(result, expected)
 
     def test_route_with_version_number_name_conflict(self):
         # type: () -> None


### PR DESCRIPTION
Added support for multiple auth modes in stone spec file in python backend code generation logic . This can now support comma separated auth modes in a stone spec file and puts the corresponding method declarations in either base.py or base_team.py.

Tested manually by updating the stone spec files for various combinations.