### PR TITLE
Implement custom annotations

### DIFF
--- a/docs/backend_ref.rst
+++ b/docs/backend_ref.rst
@@ -118,6 +118,12 @@ aliases
 alias_type_by_name
     A map from alias name to Alias object.
 
+annotation_types
+    A list of user-defined AnnotationType objects.
+
+annotation_type_by_name
+    A map from annotation name to AnnotationType object.
+
 get_imported_namespaces(must_have_imported_data_type=False)
     A list of Namespace objects. A namespace is a member of this list if it is
     imported by the current namespace and a data type or alias is referenced

--- a/docs/backend_ref.rst
+++ b/docs/backend_ref.rst
@@ -124,12 +124,15 @@ annotation_types
 annotation_type_by_name
     A map from annotation name to AnnotationType object.
 
-get_imported_namespaces(must_have_imported_data_type=False)
+get_imported_namespaces(must_have_imported_data_type=False, consider_annotations=False, consider_annotation_types=False)
     A list of Namespace objects. A namespace is a member of this list if it is
     imported by the current namespace and a data type or alias is referenced
     from it. If you want only namespaces with aliases referenced, set the
     ``must_have_imported_data_type`` parameter to true. Namespaces are in ASCII
-    order by name.
+    order by name. By default, namespaces where only annotations or annotation
+    types are referenced are not returned. To include these namespaces,
+    set ``consider_annotations`` or ``consider_annotation_types`` parameters
+    to true.
 
 get_namespaces_imported_by_route_io()
     A list of Namespace objects. A namespace is a member of this list if it is

--- a/docs/lang_ref.rst
+++ b/docs/lang_ref.rst
@@ -913,7 +913,7 @@ Note that the parameters can only be primitives (possibly nullable).
 
     namespace custom_annotation_demo
 
-    custom_annotation_type Noteworthy
+    annotation_type Noteworthy
         "Describes a field with noteworthy information"
         importance String = "low"
             "The level of importance for this field (one of 'low', 'med',

--- a/docs/lang_ref.rst
+++ b/docs/lang_ref.rst
@@ -916,6 +916,8 @@ Note that the parameters can only be primitives (possibly nullable).
     custom_annotation_type Noteworthy
         "Describes a field with noteworthy information"
         importance String = "low"
+            "The level of importance for this field (one of 'low', 'med',
+            'high')."
 
     annotation KindaNoteworthy = Noteworthy()
     annotation ReallyNoteworthy = Noteworthy(importance="high")
@@ -931,16 +933,18 @@ Note that the parameters can only be primitives (possibly nullable).
 
 In client code, you can access every field of a struct marked with a certain
 custom annotation by calling ``._process_custom_annotations(custom_annotation,
-f)`` on the struct. ``f`` will then be called with two parameters---an instance
-of the annotation type with all the parameters populated and the value of the
-field. The value of the field will then be replaced with the return value of
-``f``.
+processor)`` on the struct. ``processor`` will then be called with two
+parameters---an instance of the annotation type with all the parameters
+populated and the value of the field. The value of the field will then be
+replaced with the return value of ``f``.
 
 Note that this will also affect annotated fields that are located arbitrarily
-deep in the struct. In the example above, calling
-``secret._process_custom_annotations(Noteworthy, f)`` will result in ``f`` being
-called once with ``Noteworthy("low")`` and ``small_secret``, as well as once for
-every element of ``lots_of_big_ones`` with ``Noteworthy("high")``.
+deep in the struct. In the example above, if ``secret`` is a struct of type
+``Secrets``, then calling ``secret._process_custom_annotations(Noteworthy, f)``
+will result in ``f`` being called once as
+``f(Noteworthy("low"), secret.small_secret)`` and once as
+``f(Noteworthy("high"), x)`` for each element ``x`` of
+``secret.lots_of_big_ones``.
 
 .. _doc:
 

--- a/docs/lang_ref.rst
+++ b/docs/lang_ref.rst
@@ -902,12 +902,16 @@ compile-time warnings if the field is referenced.
 Custom annotations
 ----------
 
-**NB:** only the `python_types` backend supports custom annotations at this
+**Note:** only the `python_types` backend supports custom annotations at this
 time.
 
 A custom annotation type, possibly taking some arguments, can be defined
 similarly to structs, and then applied the same way built-in annotations are.
 Note that the parameters can only be primitives (possibly nullable).
+
+Arguments can be provided as either all positional or all keyword arguments, but
+not a mix of both. Keyword arguments are recommended to avoid depending on the
+order fields are listed in the custom annotation definition.
 
 ::
 
@@ -920,6 +924,7 @@ Note that the parameters can only be primitives (possibly nullable).
             'high')."
 
     annotation KindaNoteworthy = Noteworthy()
+    annotation MediumNoteworthy = Noteworthy("med")
     annotation ReallyNoteworthy = Noteworthy(importance="high")
 
     alias ImportantString = String
@@ -936,14 +941,14 @@ custom annotation by calling ``._process_custom_annotations(custom_annotation,
 processor)`` on the struct. ``processor`` will then be called with two
 parameters---an instance of the annotation type with all the parameters
 populated and the value of the field. The value of the field will then be
-replaced with the return value of ``f``.
+replaced with the return value of ``processor``.
 
 Note that this will also affect annotated fields that are located arbitrarily
 deep in the struct. In the example above, if ``secret`` is a struct of type
-``Secrets``, then calling ``secret._process_custom_annotations(Noteworthy, f)``
-will result in ``f`` being called once as
-``f(Noteworthy("low"), secret.small_secret)`` and once as
-``f(Noteworthy("high"), x)`` for each element ``x`` of
+``Secrets``, then calling ``secret._process_custom_annotations(Noteworthy, processor)``
+will result in ``processor`` being called once as
+``processor(Noteworthy("low"), secret.small_secret)`` and once as
+``processor(Noteworthy("high"), x)`` for each element ``x`` of
 ``secret.lots_of_big_ones``.
 
 .. _doc:

--- a/stone/backend.py
+++ b/stone/backend.py
@@ -182,6 +182,13 @@ class Backend(object):
     def clear_output_buffer(self):
         self.output = []
 
+    def indent_step(self):
+        # type: () -> int
+        """
+        Returns the size of a single indentation step.
+        """
+        return 1 if self.tabs_for_indents else 4
+
     @contextmanager
     def indent(self, dent=None):
         # type: (typing.Optional[int]) -> typing.Iterator[None]
@@ -193,10 +200,7 @@ class Backend(object):
         """
         assert dent is None or dent >= 0, 'dent must be >= 0.'
         if dent is None:
-            if self.tabs_for_indents:
-                dent = 1
-            else:
-                dent = 4
+            dent = self.indent_step()
         self.cur_indent += dent
         yield
         self.cur_indent -= dent

--- a/stone/backends/python_helpers.py
+++ b/stone/backends/python_helpers.py
@@ -124,7 +124,7 @@ def generate_imports_for_referenced_namespaces(
         the except: clause.
     """
 
-    imported_namespaces = namespace.get_imported_namespaces(consider_annotations=True)
+    imported_namespaces = namespace.get_imported_namespaces(consider_annotation_types=True)
     if not imported_namespaces:
         return
 
@@ -174,7 +174,7 @@ validators_import_with_type_ignore = _validators_import_template.format(
 )
 
 def prefix_with_ns_if_necessary(name, name_ns, source_ns):
-    # type: (str, ApiNamespace, ApiNamespace) -> str
+    # type: (typing.Text, ApiNamespace, ApiNamespace) -> typing.Text
     """
     Returns a name that can be used to reference `name` in namespace `name_ns`
     from `source_ns`.

--- a/stone/backends/python_helpers.py
+++ b/stone/backends/python_helpers.py
@@ -124,7 +124,7 @@ def generate_imports_for_referenced_namespaces(
         the except: clause.
     """
 
-    imported_namespaces = namespace.get_imported_namespaces()
+    imported_namespaces = namespace.get_imported_namespaces(consider_annotations=True)
     if not imported_namespaces:
         return
 

--- a/stone/backends/python_helpers.py
+++ b/stone/backends/python_helpers.py
@@ -173,6 +173,19 @@ validators_import_with_type_ignore = _validators_import_template.format(
     type_ignore_comment=TYPE_IGNORE_COMMENT
 )
 
+def prefix_with_ns_if_necessary(name, name_ns, source_ns):
+    # type: (str, ApiNamespace, ApiNamespace) -> str
+    """
+    Returns a name that can be used to reference `name` in namespace `name_ns`
+    from `source_ns`.
+
+    If `source_ns` and `name_ns` are the same, that's just `name`. Otherwise
+    it's `name_ns`.`name`.
+    """
+    if source_ns == name_ns:
+        return name
+    return '{}.{}'.format(fmt_namespace(name_ns.name), name)
+
 def class_name_for_data_type(data_type, ns=None):
     """
     Returns the name of the Python class that maps to a user-defined type.
@@ -185,9 +198,8 @@ def class_name_for_data_type(data_type, ns=None):
     assert is_user_defined_type(data_type) or is_alias(data_type), \
         'Expected composite type, got %r' % type(data_type)
     name = fmt_class(data_type.name)
-    if ns and data_type.namespace != ns:
-        # If from an imported namespace, add a namespace prefix.
-        name = '{}.{}'.format(fmt_namespace(data_type.namespace.name), name)
+    if ns:
+        return prefix_with_ns_if_necessary(name, data_type.namespace, ns)
     return name
 
 def class_name_for_annotation_type(annotation_type, ns=None):
@@ -196,7 +208,6 @@ def class_name_for_annotation_type(annotation_type, ns=None):
     """
     assert isinstance(annotation_type, AnnotationType)
     name = fmt_class(annotation_type.name)
-    if ns and annotation_type.namespace != ns:
-        # If from an imported namespace, add a namespace prefix.
-        name = '{}.{}'.format(fmt_namespace(annotation_type.namespace.name), name)
+    if ns:
+        return prefix_with_ns_if_necessary(name, annotation_type.namespace, ns)
     return name

--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -20,6 +20,12 @@ if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 
+class Struct(object):
+    # This is a parent class for all classes representing Stone structs. It does
+    # not provide any functionality, but it can be used to determine whether an
+    # object represents a Stone struct.
+    pass
+
 class Union(object):
     # TODO(kelkabany): Possible optimization is to remove _value if a
     # union is composed of only symbols.

--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -7,7 +7,8 @@ than being added to a project.
 """
 
 from __future__ import absolute_import, unicode_literals
-from functools import partial as partially_apply
+
+import functools
 
 try:
     from . import stone_validators as bv
@@ -124,6 +125,9 @@ class Route(object):
             self.attrs)
 
 # helper functions used when constructing custom annotation processors
+
+# put this here so that every other file doesn't need to import functools
+partially_apply = functools.partial
 
 def make_struct_annotation_processor(annotation_type, f):
     def g(struct):

--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -7,6 +7,7 @@ than being added to a project.
 """
 
 from __future__ import absolute_import, unicode_literals
+from functools import partial as partially_apply
 
 try:
     from . import stone_validators as bv
@@ -121,11 +122,6 @@ class Route(object):
             self.result_type,
             self.error_type,
             self.attrs)
-
-def partially_apply(f, arg):
-    def g(*args, **kwargs):
-        return f(arg, *args, **kwargs)
-    return g
 
 # helper functions used when constructing custom annotation processors
 

--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -183,7 +183,7 @@ class PythonTypeStubsBackend(CodeBackend):
         self.emit()
 
     def _generate_annotation_type_class_properties(self, ns, annotation_type):
-        # type: (ApiNamespace, Struct) -> None
+        # type: (ApiNamespace, AnnotationType) -> None
         for param in annotation_type.params:
             prop_name = fmt_var(param.name, True)
             param_type = self.map_stone_type_to_pep484_type(ns, param.data_type)

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -224,8 +224,10 @@ class PythonTypesBackend(CodeBackend):
         if data_type.parent_type:
             extends = class_name_for_data_type(data_type.parent_type, ns)
         else:
-            if is_union_type(data_type):
+            if is_struct_type(data_type):
                 # Use a handwritten base class
+                extends = 'bb.Struct'
+            elif is_union_type(data_type):
                 extends = 'bb.Union'
             else:
                 extends = 'object'

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -261,7 +261,7 @@ class PythonTypesBackend(CodeBackend):
                     if not param.doc:
                         continue
                     self.emit_wrapped_text(':ivar {}: {}'.format(
-                        fmt_var(param.name),
+                        fmt_var(param.name, True),
                         self.process_doc(param.doc, self._docf)),
                         subsequent_prefix='    ')
                 self.emit('"""')
@@ -276,7 +276,7 @@ class PythonTypesBackend(CodeBackend):
         # type: (ApiNamespace, AnnotationType) -> None
         with self.block('__slots__ =', delim=('[', ']')):
             for param in annotation_type.params:
-                param_name = fmt_var(param.name)
+                param_name = fmt_var(param.name, True)
                 self.emit("'_{}',".format(param_name))
         self.emit()
 
@@ -719,7 +719,7 @@ class PythonTypesBackend(CodeBackend):
                 self.emit()
 
             for field in data_type.fields:
-                field_name = fmt_func(field.name, check_reserved=True)
+                field_name = fmt_var(field.name, check_reserved=True)
                 # first, recurse into any submembers of the field that have annotations
                 for annotation_type, processor in self._generate_custom_annotation_processors(
                         ns, field.data_type):

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -276,7 +276,7 @@ class PythonTypesBackend(CodeBackend):
             self.emit()
 
     def _generate_annotation_type_class_slots(self, annotation_type):
-        # type: (ApiNamespace, AnnotationType) -> None
+        # type: (AnnotationType) -> None
         with self.block('__slots__ =', delim=('[', ']')):
             for param in annotation_type.params:
                 param_name = fmt_var(param.name, True)

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -302,17 +302,17 @@ class PythonTypesBackend(CodeBackend):
             prop_name = fmt_func(param.name, True)
             self.emit('@property')
             self.emit('def {}(self):'.format(prop_name))
-            self.emit('"""')
-            if param.doc:
-                self.emit_wrapped_text(
-                    self.process_doc(param.doc, self._docf))
-                # Sphinx wants an extra line between the text and the
-                # rtype declaration.
-                self.emit()
-            self.emit(':rtype: {}'.format(
-                self._python_type_mapping(ns, param.data_type)))
-            self.emit('"""')
             with self.indent():
+                self.emit('"""')
+                if param.doc:
+                    self.emit_wrapped_text(
+                        self.process_doc(param.doc, self._docf))
+                    # Sphinx wants an extra line between the text and the
+                    # rtype declaration.
+                    self.emit()
+                self.emit(':rtype: {}'.format(
+                    self._python_type_mapping(ns, param.data_type)))
+                self.emit('"""')
                 self.emit('return self._{}'.format(param_name))
             self.emit()
 

--- a/stone/frontend/ast.py
+++ b/stone/frontend/ast.py
@@ -250,23 +250,53 @@ class AstAnnotationRef(ASTNode):
 
 class AstAnnotationDef(ASTNode):
 
-    def __init__(self, path, lineno, lexpos, name, annotation_type, args, kwargs):
+    def __init__(self, path, lineno, lexpos, name, annotation_type,
+                 annotation_type_ns, args, kwargs):
         """
         Args:
             name (str): Name of the defined annotation.
             annotation_type (str): Type of annotation to define.
+            annotation_type_ns (Optional[str]): Namespace where the annotation
+              type was defined. If None, current namespace or builtin.
             args (str): Arguments to define annotation.
             kwargs (str): Keyword Arguments to define annotation.
         """
         super(AstAnnotationDef, self).__init__(path, lineno, lexpos)
         self.name = name
         self.annotation_type = annotation_type
+        self.annotation_type_ns = annotation_type_ns
         self.args = args
         self.kwargs = kwargs
 
     def __repr__(self):
-        return 'AstAnnotationDef({!r}, {!r}, {!r}, {!r})'.format(
-            self.name, self.annotation_type, self.args, self.kwargs
+        return 'AstAnnotationDef({!r}, {!r}, {!r}, {!r}, {!r})'.format(
+            self.name,
+            self.annotation_type,
+            self.annotation_type_ns,
+            self.args,
+            self.kwargs,
+        )
+
+class AstAnnotationTypeDef(ASTNode):
+
+    def __init__(self, path, lineno, lexpos, name, doc, params):
+        """
+        Args:
+            name (str): Name of the defined annotation type.
+            doc (str): Docstring for the defined annotation type.
+            params (List[AstField]): Parameters that can be passed to the
+                annotation type.
+        """
+        super(AstAnnotationTypeDef, self).__init__(path, lineno, lexpos)
+        self.name = name
+        self.doc = doc
+        self.params = params
+
+    def __repr__(self):
+        return 'AstAnnotationTypeDef({!r}, {!r}, {!r})'.format(
+            self.name,
+            self.doc,
+            self.params,
         )
 
 class AstField(ASTNode):

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -669,7 +669,8 @@ class IRGenerator(object):
 
                     if annotation.annotation_type_name not in annotation_type_env:
                         raise InvalidSpec(
-                            'Annotation type %s does not exist' % quote(annotation.annotation_type_name), *loc)
+                            'Annotation type %s does not exist' %
+                            quote(annotation.annotation_type_name), *loc)
 
                     annotation_type = annotation_type_env[annotation.annotation_type_name]
 

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -410,6 +410,8 @@ class IRGenerator(object):
             return 'alias'
         elif isinstance(item, AstNamespace):
             return 'namespace'
+        elif isinstance(item, AstAnnotationTypeDef):
+            return 'annotation type'
         else:
             raise AssertionError('unhandled type %r' % item)
 

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -522,15 +522,17 @@ class IRGenerator(object):
 
             if isinstance(dt, Void):
                 raise InvalidSpec(
-                    'Parameters of annotation types cannot be Void',
+                    'Parameter {} cannot be Void.'.format(quote(param.name)),
                     param.lineno, param.path)
             if nullable_dt and param.has_default:
                 raise InvalidSpec(
-                    'Nullable parameters cannot have default values',
+                    'Parameter {} cannot be a nullable type and have '
+                    'a default specified.'.format(quote(param.name)),
                     param.lineno, param.path)
             if not is_primitive_type(dt):
                 raise InvalidSpec(
-                    'Parameters of annotation types must be primitive or Nullable',
+                    'Parameter {} must have a primitive type (possibly '
+                    'nullable).'.format(quote(param.name)),
                     param.lineno, param.path)
 
             params.append(AnnotationTypeParam(param.name, param_type, param.doc,
@@ -667,7 +669,7 @@ class IRGenerator(object):
 
                     if annotation.annotation_type_name not in annotation_type_env:
                         raise InvalidSpec(
-                            'Symbol %s is undefined' % quote(annotation.annotation_type_name), *loc)
+                            'Annotation type %s does not exist' % quote(annotation.annotation_type_name), *loc)
 
                     annotation_type = annotation_type_env[annotation.annotation_type_name]
 
@@ -1142,7 +1144,7 @@ class IRGenerator(object):
 
         if annotation_ref.annotation not in env:
             raise InvalidSpec(
-                'Symbol %s is undefined.' % quote(annotation_ref.annotation), *loc)
+                'Annotation %s does not exist.' % quote(annotation_ref.annotation), *loc)
 
         return env[annotation_ref.annotation]
 

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -480,10 +480,16 @@ class IRGenerator(object):
 
         namespace = self.api.ensure_namespace(env.namespace_name)
 
+        if item.args and item.kwargs:
+            raise InvalidSpec(
+                'Annotations accept either positional or keyword arguments, not both',
+                item.lineno, item.path,
+            )
+
         if ((item.annotation_type_ns is None)
                 and (item.annotation_type in BUILTIN_ANNOTATION_CLASS_BY_STRING)):
             annotation_class = BUILTIN_ANNOTATION_CLASS_BY_STRING[item.annotation_type]
-            annotation = annotation_class(item.name, namespace, item, *item.args)
+            annotation = annotation_class(item.name, namespace, item, *item.args, **item.kwargs)
         else:
             if item.annotation_type_ns is not None:
                 namespace.add_imported_namespace(

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -488,7 +488,7 @@ class IRGenerator(object):
             if item.annotation_type_ns is not None:
                 namespace.add_imported_namespace(
                     self.api.ensure_namespace(item.annotation_type_ns),
-                    imported_data_type=True)
+                    imported_annotation_type=True)
 
             annotation = CustomAnnotation(item.name, namespace, item,
                 item.annotation_type, item.annotation_type_ns, item.args,

--- a/stone/frontend/lexer.py
+++ b/stone/frontend/lexer.py
@@ -165,7 +165,7 @@ class Lexer(object):
     KEYWORDS = [
         'alias',
         'annotation',
-        'custom_annotation_type',
+        'annotation_type',
         'attrs',
         'by',
         'deprecated',
@@ -184,7 +184,7 @@ class Lexer(object):
 
     RESERVED = {
         'annotation': 'ANNOTATION',
-        'custom_annotation_type': 'ANNOTATION_TYPE',
+        'annotation_type': 'ANNOTATION_TYPE',
         'attrs': 'ATTRS',
         'deprecated': 'DEPRECATED',
         'by': 'BY',
@@ -223,6 +223,17 @@ class Lexer(object):
     def t_ANY_ID(self, token):
         r'[a-zA-Z_][a-zA-Z0-9_-]*'
         if token.value in self.KEYWORDS:
+            if (token.value == 'annotation_type') and self.cur_indent:
+                # annotation_type was added as a reserved keyword relatively
+                # late, when there was already an identifer with the same name
+                # in an internal spec. because annotation_type-the-keyword can
+                # only be used at the beginning of a non-indented line, this
+                # check lets both the keyword and the identifer coexist and
+                # maintains backward compatibility.
+                # TODO: this is kind of a hack, and we should get rid of it if
+                # the internal spec no longer exists or the lexer gets better
+                # at telling keywords from identifiers in general.
+                return token
             token.type = self.RESERVED.get(token.value, 'KEYWORD')
             return token
         else:

--- a/stone/frontend/lexer.py
+++ b/stone/frontend/lexer.py
@@ -225,14 +225,13 @@ class Lexer(object):
         if token.value in self.KEYWORDS:
             if (token.value == 'annotation_type') and self.cur_indent:
                 # annotation_type was added as a reserved keyword relatively
-                # late, when there was already an identifer with the same name
-                # in an internal spec. because annotation_type-the-keyword can
+                # late, when there could be identifers with the same name
+                # in existing specs. because annotation_type-the-keyword can
                 # only be used at the beginning of a non-indented line, this
                 # check lets both the keyword and the identifer coexist and
                 # maintains backward compatibility.
-                # TODO: this is kind of a hack, and we should get rid of it if
-                # the internal spec no longer exists or the lexer gets better
-                # at telling keywords from identifiers in general.
+                # Note: this is kind of a hack, and we should get rid of it if
+                # the lexer gets better at telling keywords from identifiers in general.
                 return token
             token.type = self.RESERVED.get(token.value, 'KEYWORD')
             return token

--- a/stone/frontend/lexer.py
+++ b/stone/frontend/lexer.py
@@ -165,6 +165,7 @@ class Lexer(object):
     KEYWORDS = [
         'alias',
         'annotation',
+        'custom_annotation_type',
         'attrs',
         'by',
         'deprecated',
@@ -183,6 +184,7 @@ class Lexer(object):
 
     RESERVED = {
         'annotation': 'ANNOTATION',
+        'custom_annotation_type': 'ANNOTATION_TYPE',
         'attrs': 'ATTRS',
         'deprecated': 'DEPRECATED',
         'by': 'BY',

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -20,6 +20,7 @@ if _MYPY:
     from .data_types import (  # noqa: F401 # pylint: disable=unused-import
         Alias,
         Annotation,
+        AnnotationType,
         DataType,
         List as DataTypeList,
         Nullable,
@@ -102,18 +103,20 @@ class ApiNamespace(object):
     def __init__(self, name):
         # type: (typing.Text) -> None
         self.name = name
-        self.doc = None                 # type: typing.Optional[six.text_type]
-        self.routes = []                # type: typing.List[ApiRoute]
+        self.doc = None                    # type: typing.Optional[six.text_type]
+        self.routes = []                   # type: typing.List[ApiRoute]
         # TODO (peichao): route_by_name is deprecated by routes_by_name and should be removed.
-        self.route_by_name = {}         # type: typing.Dict[typing.Text, ApiRoute]
-        self.routes_by_name = {}        # type: typing.Dict[typing.Text, ApiRoutesByVersion]
-        self.data_types = []            # type: typing.List[UserDefined]
-        self.data_type_by_name = {}     # type: typing.Dict[str, UserDefined]
-        self.aliases = []               # type: typing.List[Alias]
-        self.alias_by_name = {}         # type: typing.Dict[str, Alias]
-        self.annotations = []           # type: typing.List[Annotation]
-        self.annotation_by_name = {}    # type: typing.Dict[str, Annotation]
-        self._imported_namespaces = {}  # type: typing.Dict[ApiNamespace, _ImportReason]
+        self.route_by_name = {}            # type: typing.Dict[typing.Text, ApiRoute]
+        self.routes_by_name = {}           # type: typing.Dict[typing.Text, ApiRoutesByVersion]
+        self.data_types = []               # type: typing.List[UserDefined]
+        self.data_type_by_name = {}        # type: typing.Dict[str, UserDefined]
+        self.aliases = []                  # type: typing.List[Alias]
+        self.alias_by_name = {}            # type: typing.Dict[str, Alias]
+        self.annotations = []              # type: typing.List[Annotation]
+        self.annotation_by_name = {}       # type: typing.Dict[str, Annotation]
+        self.annotation_types = []         # type: typing.List[AnnotationType]
+        self.annotation_type_by_name = {}  # type: typing.Dict[str, AnnotationType]
+        self._imported_namespaces = {}     # type: typing.Dict[ApiNamespace, _ImportReason]
 
     def add_doc(self, docstring):
         # type: (six.text_type) -> None
@@ -155,6 +158,11 @@ class ApiNamespace(object):
         # type: (Annotation) -> None
         self.annotations.append(annotation)
         self.annotation_by_name[annotation.name] = annotation
+
+    def add_annotation_type(self, annotation_type):
+        # type: (AnnotationType) -> None
+        self.annotation_types.append(annotation_type)
+        self.annotation_type_by_name[annotation_type.name] = annotation_type
 
     def add_imported_namespace(self,
                                namespace,

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -171,7 +171,7 @@ class ApiNamespace(object):
                                imported_data_type=False,
                                imported_annotation=False,
                                imported_annotation_type=False):
-        # type: (ApiNamespace, bool, bool, bool) -> None
+        # type: (ApiNamespace, bool, bool, bool, bool) -> None
         """
         Keeps track of namespaces that this namespace imports.
 
@@ -282,9 +282,11 @@ class ApiNamespace(object):
                 data_types.add(data_user_type)
         return data_types
 
-    def get_imported_namespaces(self, must_have_imported_data_type=False,
-                                consider_annotations=False):
-        # type: (bool) -> typing.List[ApiNamespace]
+    def get_imported_namespaces(self,
+                                must_have_imported_data_type=False,
+                                consider_annotations=False,
+                                consider_annotation_types=False):
+        # type: (bool, bool, bool) -> typing.List[ApiNamespace]
         """
         Returns a list of Namespace objects. A namespace is a member of this
         list if it is imported by the current namespace and a data type is
@@ -294,8 +296,9 @@ class ApiNamespace(object):
             must_have_imported_data_type (bool): If true, result does not
                 include namespaces that were not imported for data types.
             consider_annotations (bool): If false, result does not include
-                namespaces that were only imported for annotations or
-                annotation types.
+                namespaces that were only imported for annotations
+            consider_annotation_types (bool): If false, result does not
+                include namespaces that were only imported for annotation types.
 
         Returns:
             List[Namespace]: A list of imported namespaces.
@@ -304,7 +307,13 @@ class ApiNamespace(object):
         for imported_namespace, reason in self._imported_namespaces.items():
             if must_have_imported_data_type and not reason.data_type:
                 continue
-            if (not consider_annotations) and not (reason.data_type or reason.alias):
+            if (not consider_annotations) and not (
+                    reason.data_type or reason.alias or reason.annotation_type
+            ):
+                continue
+            if (not consider_annotation_types) and not (
+                    reason.data_type or reason.alias or reason.annotation
+            ):
                 continue
 
             imported_namespaces.append(imported_namespace)

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1756,6 +1756,13 @@ class CustomAnnotation(Annotation):
                     (param.name, self.annotation_type.name), self._ast_node.lineno,
                     self._ast_node.path)
 
+        acceptable_param_names = set((param.name for param in self.annotation_type.params))
+        for param_name in self.kwargs:
+            if param_name not in acceptable_param_names:
+                raise InvalidSpec('Unknown parameter %s passed to annotation type %s' %
+                    (param_name, self.annotation_type.name), self._ast_node.lineno,
+                    self._ast_node.path)
+
 
 class Alias(Composite):
     """

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -788,7 +788,6 @@ class UserDefined(Composite):
                         annotation.annotation_type.namespace,
                         imported_annotation_type=True)
 
-
         # Indicate that the attributes of the type have been populated.
         self._is_forward_ref = False
 

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -575,6 +575,7 @@ class Field(object):
         self.omitted_caller = None
         self.deprecated = None
         self.preview = None
+        self.custom_annotations = []
 
     def set_annotations(self, annotations):
         if not annotations:
@@ -615,6 +616,8 @@ class Field(object):
                     raise InvalidSpec("Redactor already set as %r." %
                                       str(self.redactor), self._ast_node.lineno)
                 self.redactor = annotation
+            elif isinstance(annotation, CustomAnnotation):
+                self.custom_annotations.append(annotation)
             else:
                 raise InvalidSpec(
                     'Annotation %r not recognized for field.' % annotation, self._ast_node.lineno)
@@ -770,6 +773,14 @@ class UserDefined(Composite):
                         % (field.name, cur_type.name, lineno),
                         field._ast_node.lineno)
             cur_type = cur_type.parent_type
+
+        # Import namespaces containing any custom annotations
+        for field in self.fields:
+            for annotation in field.custom_annotations:
+                if annotation.namespace.name != self.namespace.name:
+                    self.namespace.add_imported_namespace(
+                        annotation.namespace,
+                        imported_data_type=True)
 
         # Indicate that the attributes of the type have been populated.
         self._is_forward_ref = False
@@ -1582,9 +1593,64 @@ class TagRef(object):
         return 'TagRef(%r, %r)' % (self.union_data_type, self.tag_name)
 
 
+class AnnotationTypeParam(object):
+    """
+    A parameter that can be supplied to a custom annotation type.
+    """
+    def __init__(self, name, data_type, doc, has_default, default, ast_node):
+        self.name = name
+        self.data_type = data_type
+        self.raw_doc = doc
+        self.doc = doc_unwrap(doc)
+        self.has_default = has_default
+        self.default = default
+        self._ast_node = ast_node
+
+        if self.has_default:
+            try:
+                self.data_type.check(self.default)
+            except ValueError as e:
+                raise InvalidSpec('Default value for parameter %s is invalid: %s' % (
+                    self.name, e), self._ast_node.lineno, self._ast_node.path)
+
+
+class AnnotationType(object):
+    """
+    Used when a spec defines a custom annotation type.
+    """
+    def __init__(self, name, namespace, doc, params):
+        self.name = name
+        self.namespace = namespace
+        self.raw_doc = doc
+        self.doc = doc_unwrap(doc)
+        self.params = params
+
+        self._params_by_name = {}  # type: Dict[str, AnnotationTypeParam]
+        for param in self.params:
+            if param.name in self._params_by_name:
+                orig_lineno = self._params_by_name[param.name]._ast_node.lineno
+                raise InvalidSpec("Parameter '%s' already defined on line %s." %
+                                  (param.name, orig_lineno),
+                                  param._ast_node.lineno, param._ast_node.path)
+            self._params_by_name[param.name] = param
+
+    def has_documented_type_or_params(self):
+        """Returns whether this type, or any of its parameters, are documented.
+
+        Use this when deciding whether to create a block of documentation for
+        this type.
+        """
+        return self.doc or self.has_documented_params()
+
+    def has_documented_params(self):
+        """Returns whether at least one param is documented."""
+        return any(param.doc for param in self.params)
+
+
 class Annotation(object):
     """
-    Used when a field is annotated with a pre-defined Stone action.
+    Used when a field is annotated with a pre-defined Stone action or a custom
+    annotation.
     """
     def __init__(self, name, namespace, ast_node):
         self.name = name
@@ -1645,6 +1711,45 @@ class RedactedHash(Redacted):
         return 'RedactedHash(%r, %r, %r)' % (self.name, self.namespace, self.regex)
 
 
+class CustomAnnotation(Annotation):
+    """
+    Used when a field is annotated with a custom annotation type.
+    """
+    def __init__(self, name, namespace, ast_node, annotation_type,
+                 annotation_type_ns, args, kwargs):
+        super(CustomAnnotation, self).__init__(name, namespace, ast_node)
+        self.annotation_type_name = annotation_type
+        self.annotation_type_ns = annotation_type_ns
+        self.args = args
+        self.kwargs = kwargs
+
+        self.annotation_type = None
+
+    def set_attributes(self, annotation_type):
+        self.annotation_type = annotation_type
+
+        if self.args:
+            raise InvalidSpec('Annotations cannot accept positional arguments',
+                self._ast_node.lineno, self._ast_node.path)
+
+        for param in self.annotation_type.params:
+            if param.name in self.kwargs:
+                try:
+                    param.data_type.check(self.kwargs[param.name])
+                except ValueError as e:
+                    raise InvalidSpec('Invalid value for parameter %s of annotation type %s: %s' %
+                        (param.name, self.annotation_type.name, e), self._ast_node.lineno,
+                        self._ast_node.path)
+            elif isinstance(param.data_type, Nullable):
+                self.kwargs[param.name] = None
+            elif param.has_default:
+                self.kwargs[param.name] = param.default
+            else:
+                raise InvalidSpec('No value specified for parameter %s of annotation type %s' %
+                    (param.name, self.annotation_type.name), self._ast_node.lineno,
+                    self._ast_node.path)
+
+
 class Alias(Composite):
     """
     NOTE: The categorization of aliases as a composite type is arbitrary.
@@ -1673,6 +1778,7 @@ class Alias(Composite):
         self.doc = None
         self.data_type = None
         self.redactor = None
+        self.custom_annotations = []
 
     def set_annotations(self, annotations):
         for annotation in annotations:
@@ -1682,8 +1788,15 @@ class Alias(Composite):
                     raise InvalidSpec("Redactor already set as %r" %
                                       str(self.redactor), self._ast_node.lineno)
                 self.redactor = annotation
+            elif isinstance(annotation, CustomAnnotation):
+                if annotation.namespace.name != self.namespace.name:
+                    self.namespace.add_imported_namespace(
+                        annotation.namespace,
+                        imported_data_type=True)
+
+                self.custom_annotations.append(annotation)
             else:
-                raise InvalidSpec("Aliases only support 'Redacted', not %r" %
+                raise InvalidSpec("Aliases only support 'Redacted' and custom annotations, not %r" %
                                   str(annotation), self._ast_node.lineno)
 
     def set_attributes(self, doc, data_type):

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1625,7 +1625,7 @@ class AnnotationType(object):
         self.doc = doc_unwrap(doc)
         self.params = params
 
-        self._params_by_name = {}  # type: Dict[str, AnnotationTypeParam]
+        self._params_by_name = {}  # type: typing.Dict[str, AnnotationTypeParam]
         for param in self.params:
             if param.name in self._params_by_name:
                 orig_lineno = self._params_by_name[param.name]._ast_node.lineno

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -777,10 +777,17 @@ class UserDefined(Composite):
         # Import namespaces containing any custom annotations
         for field in self.fields:
             for annotation in field.custom_annotations:
+                # first, check if we need to import the annotation itself
                 if annotation.namespace.name != self.namespace.name:
                     self.namespace.add_imported_namespace(
                         annotation.namespace,
-                        imported_data_type=True)
+                        imported_annotation=True)
+                # then also check the annotation *type*
+                if annotation.annotation_type.namespace.name != self.namespace.name:
+                    self.namespace.add_imported_namespace(
+                        annotation.annotation_type.namespace,
+                        imported_annotation_type=True)
+
 
         # Indicate that the attributes of the type have been populated.
         self._is_forward_ref = False
@@ -1789,10 +1796,16 @@ class Alias(Composite):
                                       str(self.redactor), self._ast_node.lineno)
                 self.redactor = annotation
             elif isinstance(annotation, CustomAnnotation):
+                # first, check if we need to import the annotation itself
                 if annotation.namespace.name != self.namespace.name:
                     self.namespace.add_imported_namespace(
                         annotation.namespace,
-                        imported_data_type=True)
+                        imported_annotation=True)
+                # then also check the annotation *type*
+                if annotation.annotation_type.namespace.name != self.namespace.name:
+                    self.namespace.add_imported_namespace(
+                        annotation.annotation_type.namespace,
+                        imported_annotation_type=True)
 
                 self.custom_annotations.append(annotation)
             else:

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1722,10 +1722,10 @@ class CustomAnnotation(Annotation):
     """
     Used when a field is annotated with a custom annotation type.
     """
-    def __init__(self, name, namespace, ast_node, annotation_type,
+    def __init__(self, name, namespace, ast_node, annotation_type_name,
                  annotation_type_ns, args, kwargs):
         super(CustomAnnotation, self).__init__(name, namespace, ast_node)
-        self.annotation_type_name = annotation_type
+        self.annotation_type_name = annotation_type_name
         self.annotation_type_ns = annotation_type_ns
         self.args = args
         self.kwargs = kwargs

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1684,9 +1684,9 @@ class Omitted(Annotation):
     """
     Used when a field is annotated for omission.
     """
-    def __init__(self, name, namespace, ast_node, permission):
+    def __init__(self, name, namespace, ast_node, omitted_caller):
         super(Omitted, self).__init__(name, namespace, ast_node)
-        self.omitted_caller = permission
+        self.omitted_caller = omitted_caller
 
     def __repr__(self):
         return 'Omitted(%r, %r, %r)' % (self.name, self.namespace, self.omitted_caller)

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -227,7 +227,10 @@ except (ImportError, SystemError, ValueError):
     # Catch errors raised when importing a relative module when not in a package.
     # This makes testing this file directly (outside of a package) easier.
     import stone_validators as bv  # type: ignore
-    import stone_base as bb  # type: ignore"""
+    import stone_base as bb  # type: ignore
+
+T = TypeVar('T', bound=bb.AnnotationType)
+U = TypeVar('U')"""
 
 class TestPythonTypeStubs(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -262,6 +265,12 @@ class TestPythonTypeStubs(unittest.TestCase):
 
                 @f1.deleter
                 def f1(self) -> None: ...
+
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
 
             Struct1_validator: bv.Validator = ...
 
@@ -300,13 +309,22 @@ class TestPythonTypeStubs(unittest.TestCase):
                 @f4.deleter
                 def f4(self) -> None: ...
 
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
+
             Struct2_validator: bv.Validator = ...
 
 
             from typing import (
+                Callable,
                 Dict,
                 List,
                 Text,
+                Type,
+                TypeVar,
             )
 
             import datetime
@@ -344,12 +362,21 @@ class TestPythonTypeStubs(unittest.TestCase):
                 @nullable_list.deleter
                 def nullable_list(self) -> None: ...
 
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
+
             NestedTypes_validator: bv.Validator = ...
 
 
             from typing import (
+                Callable,
                 List,
                 Optional,
+                Type,
+                TypeVar,
             )
             """).format(headers=_headers)
         self.assertEqual(result, expected)
@@ -369,6 +396,12 @@ class TestPythonTypeStubs(unittest.TestCase):
 
                 def is_last(self) -> bool: ...
 
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
+
             Union_validator: bv.Validator = ...
 
             class Shape(bb.Union):
@@ -383,12 +416,24 @@ class TestPythonTypeStubs(unittest.TestCase):
 
                 def get_circle(self) -> float: ...
 
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
+
             Shape_validator: bv.Validator = ...
 
+
+            from typing import (
+                Callable,
+                Type,
+                TypeVar,
+            )
             """).format(headers=_headers)
         self.assertEqual(result, expected)
 
-    def test__generate_base_namespace_module_with_empty_union__generates_pass(self):
+    def test__generate_base_namespace_module_with_empty_union(self):
         # type: () -> None
         ns = _make_namespace_with_empty_union()
         result = self._evaluate_namespace(ns)
@@ -396,10 +441,20 @@ class TestPythonTypeStubs(unittest.TestCase):
             {headers}
 
             class EmptyUnion(bb.Union):
-                pass
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
 
             EmptyUnion_validator: bv.Validator = ...
 
+
+            from typing import (
+                Callable,
+                Type,
+                TypeVar,
+            )
             """).format(headers=_headers)
         self.assertEqual(result, expected)
 
@@ -413,6 +468,10 @@ class TestPythonTypeStubs(unittest.TestCase):
             route_one: bb.Route = ...
             route_one_v2: bb.Route = ...
 
+
+            from typing import (
+                TypeVar,
+            )
             """).format(headers=_headers)
         self.assertEqual(result, expected)
 
@@ -446,10 +505,22 @@ class TestPythonTypeStubs(unittest.TestCase):
                 @f1.deleter
                 def f1(self) -> None: ...
 
+                def _process_custom_annotations(
+                    self,
+                    annotation_type: Type[T],
+                    f: Callable[[T, U], U],
+                ) -> None: ...
+
             Struct1_validator: bv.Validator = ...
 
             AliasToStruct1_validator: bv.Validator = ...
             AliasToStruct1 = Struct1
             NotUserDefinedAlias_validator: bv.Validator = ...
+
+            from typing import (
+                Callable,
+                Type,
+                TypeVar,
+            )
             """).format(headers=_headers)
         self.assertEqual(result, expected)

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -93,48 +93,6 @@ class TestGeneratedPythonTypes(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_custom_annotations(self):
-        # type: () -> None
-
-        route1 = ApiRoute('alpha/get_metadata', 1, None)
-        route1.set_attributes(None, None, Void(), Void(), Void(), {})
-        route2 = ApiRoute('alpha/get_metadata', 2, None)
-        route2.set_attributes(None, None, Void(), Int32(), Void(), {})
-        ns = ApiNamespace('files')
-        ns.add_route(route1)
-        ns.add_route(route2)
-
-        result = self._evaluate_namespace(ns)
-
-        expected = textwrap.dedent("""\
-            alpha_get_metadata = bb.Route(
-                'alpha/get_metadata',
-                1,
-                False,
-                bv.Void(),
-                bv.Void(),
-                bv.Void(),
-                {},
-            )
-            alpha_get_metadata_v2 = bb.Route(
-                'alpha/get_metadata',
-                2,
-                False,
-                bv.Void(),
-                bv.Int32(),
-                bv.Void(),
-                {},
-            )
-
-            ROUTES = {
-                'alpha/get_metadata': alpha_get_metadata,
-                'alpha/get_metadata:2': alpha_get_metadata_v2,
-            }
-
-        """)
-
-        self.assertEqual(result, expected)
-
     def test_route_with_version_number_name_conflict(self):
         # type: () -> None
 

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -96,7 +96,6 @@ class TestGeneratedPythonTypes(unittest.TestCase):
     def test_custom_annotations(self):
         # type: () -> None
 
-
         route1 = ApiRoute('alpha/get_metadata', 1, None)
         route1.set_attributes(None, None, Void(), Void(), Void(), {})
         route2 = ApiRoute('alpha/get_metadata', 2, None)
@@ -251,7 +250,7 @@ class TestGeneratedPythonTypes(unittest.TestCase):
 
             MyStruct_validator = bv.Struct(MyStruct)
 
-        ''')
+        ''') # noqa
 
         self.assertEqual(result, expected)
 

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -1,7 +1,17 @@
 import textwrap
 
 from stone.backends.python_types import PythonTypesBackend
-from stone.ir import ApiNamespace, ApiRoute, Void, Int32, Struct
+from stone.ir import (
+    AnnotationType,
+    AnnotationTypeParam,
+    ApiNamespace,
+    ApiRoute,
+    CustomAnnotation,
+    Int32,
+    Struct,
+    StructField,
+    Void,
+)
 from test.backend_test_util import _mock_emit
 
 MYPY = False
@@ -31,8 +41,61 @@ class TestGeneratedPythonTypes(unittest.TestCase):
         result = "".join(emitted)
         return result
 
+    def _evaluate_struct(self, ns, struct):
+        # type: (ApiNamespace, Struct) -> typing.Text
+        backend = PythonTypesBackend(
+            target_folder_path='output',
+            args=['-r', 'dropbox.dropbox.Dropbox.{ns}_{route}'])
+        emitted = _mock_emit(backend)
+        backend._generate_struct_class(ns, struct)
+        result = "".join(emitted)
+        return result
+
     def test_route_with_version_number(self):
         # type: () -> None
+
+        route1 = ApiRoute('alpha/get_metadata', 1, None)
+        route1.set_attributes(None, None, Void(), Void(), Void(), {})
+        route2 = ApiRoute('alpha/get_metadata', 2, None)
+        route2.set_attributes(None, None, Void(), Int32(), Void(), {})
+        ns = ApiNamespace('files')
+        ns.add_route(route1)
+        ns.add_route(route2)
+
+        result = self._evaluate_namespace(ns)
+
+        expected = textwrap.dedent("""\
+            alpha_get_metadata = bb.Route(
+                'alpha/get_metadata',
+                1,
+                False,
+                bv.Void(),
+                bv.Void(),
+                bv.Void(),
+                {},
+            )
+            alpha_get_metadata_v2 = bb.Route(
+                'alpha/get_metadata',
+                2,
+                False,
+                bv.Void(),
+                bv.Int32(),
+                bv.Void(),
+                {},
+            )
+
+            ROUTES = {
+                'alpha/get_metadata': alpha_get_metadata,
+                'alpha/get_metadata:2': alpha_get_metadata_v2,
+            }
+
+        """)
+
+        self.assertEqual(result, expected)
+
+    def test_custom_annotations(self):
+        # type: () -> None
+
 
         route1 = ApiRoute('alpha/get_metadata', 1, None)
         route1.set_attributes(None, None, Void(), Void(), Void(), {})
@@ -89,5 +152,107 @@ class TestGeneratedPythonTypes(unittest.TestCase):
         self.assertEqual(
             'There is a name conflict between {!r} and {!r}'.format(route1, route2),
             str(cm.exception))
+
+    def test_struct_with_custom_annotations(self):
+        # type: () -> None
+        ns = ApiNamespace('files')
+        annotation_type = AnnotationType('MyAnnotationType', ns, None, [
+            AnnotationTypeParam('test_param', Int32(), None, False, None, None)
+        ])
+        ns.add_annotation_type(annotation_type)
+        annotation = CustomAnnotation('MyAnnotation', ns, None, 'MyAnnotationType',
+            None, [], {'test_param': 42})
+        annotation.set_attributes(annotation_type)
+        ns.add_annotation(annotation)
+        struct = Struct('MyStruct', ns, None)
+        struct.set_attributes(None, [
+            StructField('annotated_field', Int32(), None, None),
+            StructField('unannotated_field', Int32(), None, None),
+        ])
+        struct.fields[0].set_annotations([annotation])
+
+        result = self._evaluate_struct(ns, struct)
+
+        expected = textwrap.dedent('''\
+            class MyStruct(bb.Struct):
+
+                __slots__ = [
+                    '_annotated_field_value',
+                    '_annotated_field_present',
+                    '_unannotated_field_value',
+                    '_unannotated_field_present',
+                ]
+
+                _has_required_fields = True
+
+                def __init__(self,
+                             annotated_field=None,
+                             unannotated_field=None):
+                    self._annotated_field_value = None
+                    self._annotated_field_present = False
+                    self._unannotated_field_value = None
+                    self._unannotated_field_present = False
+                    if annotated_field is not None:
+                        self.annotated_field = annotated_field
+                    if unannotated_field is not None:
+                        self.unannotated_field = unannotated_field
+
+                @property
+                def annotated_field(self):
+                    """
+                    :rtype: long
+                    """
+                    if self._annotated_field_present:
+                        return self._annotated_field_value
+                    else:
+                        raise AttributeError("missing required field 'annotated_field'")
+
+                @annotated_field.setter
+                def annotated_field(self, val):
+                    val = self._annotated_field_validator.validate(val)
+                    self._annotated_field_value = val
+                    self._annotated_field_present = True
+
+                @annotated_field.deleter
+                def annotated_field(self):
+                    self._annotated_field_value = None
+                    self._annotated_field_present = False
+
+                @property
+                def unannotated_field(self):
+                    """
+                    :rtype: long
+                    """
+                    if self._unannotated_field_present:
+                        return self._unannotated_field_value
+                    else:
+                        raise AttributeError("missing required field 'unannotated_field'")
+
+                @unannotated_field.setter
+                def unannotated_field(self, val):
+                    val = self._unannotated_field_validator.validate(val)
+                    self._unannotated_field_value = val
+                    self._unannotated_field_present = True
+
+                @unannotated_field.deleter
+                def unannotated_field(self):
+                    self._unannotated_field_value = None
+                    self._unannotated_field_present = False
+
+                def _process_custom_annotations(self, annotation_type, f):
+                    if annotation_type is MyAnnotationType:
+                        self.annotated_field = f(MyAnnotationType(test_param=42), self.annotated_field)
+
+                def __repr__(self):
+                    return 'MyStruct(annotated_field={!r}, unannotated_field={!r})'.format(
+                        self._annotated_field_value,
+                        self._unannotated_field_value,
+                    )
+
+            MyStruct_validator = bv.Struct(MyStruct)
+
+        ''')
+
+        self.assertEqual(result, expected)
 
     # TODO: add more unit tests for client code generation

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -198,7 +198,7 @@ class TestGeneratedPythonTypes(unittest.TestCase):
 
                 def _process_custom_annotations(self, annotation_type, f):
                     if annotation_type is MyAnnotationType:
-                        self.annotated_field = f(MyAnnotationType(test_param=42), self.annotated_field)
+                        self.annotated_field = bb.partially_apply(f, MyAnnotationType(test_param=42))(self.annotated_field)
 
                 def __repr__(self):
                     return 'MyStruct(annotated_field={!r}, unannotated_field={!r})'.format(

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -4762,7 +4762,7 @@ class TestStone(unittest.TestCase):
             struct S
                 f String
 
-            custom_annotation_type AT
+            annotation_type AT
                 s S
             """)
         with self.assertRaises(InvalidSpec) as cm:
@@ -4778,7 +4778,7 @@ class TestStone(unittest.TestCase):
 
             annotation Deprecated = Deprecated()
 
-            custom_annotation_type AT
+            annotation_type AT
                 s String
                     @Deprecated
             """)
@@ -4793,7 +4793,7 @@ class TestStone(unittest.TestCase):
         text = textwrap.dedent("""\
             namespace test
 
-            custom_annotation_type Deprecated
+            annotation_type Deprecated
                 s String
             """)
         with self.assertRaises(InvalidSpec) as cm:
@@ -4807,7 +4807,7 @@ class TestStone(unittest.TestCase):
         text = textwrap.dedent("""\
             namespace test
 
-            custom_annotation_type Important
+            annotation_type Important
                 importance String = "very"
 
             annotation VeryImportant = Important()

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,8 @@ usedevelop = true
 
 [testenv:mypy]
 
+basepython = python3.4
+
 commands =
     ./mypy-run.sh
 


### PR DESCRIPTION
This PR implements custom annotation types, which can be defined and applied to arbitrary aliases and fields, then used in client code for application-specific processing.

At this time, only the Python backends expose custom annotations.

If you've seen the pre-PR branch that was shared internally a week ago, the main differences are that existing tests now pass, new ones have been added, and documentation has been added.