### PR TITLE
assert equals for float fields

### DIFF
--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -299,6 +299,7 @@ class TestStone(unittest.TestCase):
         self.assertEqual(out[1].fields[3].default, -4.2)
         self.assertEqual(out[1].fields[4].default, -5e-3)
         self.assertEqual(out[1].fields[5].default, -5.1e-3)
+        self.assertEqual(out[1].fields[6].default, 1)
 
         # float type should always have default value in float
         api = specs_to_ir([('test.stone', text)])


### PR DESCRIPTION
Allows project to perform compileJava task on project build for Java SDK project, as it otherwise causes the below error.

```
> Task :compileJava   
warning: [options] bootstrap class path not set in conjunction with -source 1.6   
/Users/sean/Documents/Clients/Simflofy/seanjavasdk/dropbox-sdk-java/build/generated/source/stone/main/src/com/dropbox/core/v2/files/GetTemporaryUploadLinkArg.java:166: error: incompatible types: int cannot be converted to Double
                Double f_duration = 14400;
                                    ^   
1 error
```