### PR TITLE
Minor cleanup of _process_custom_annotations

### DIFF
--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -31,7 +31,7 @@ if _MYPY:
 
 class Struct(object):
     # This is a base class for all classes representing Stone structs.
-    def _process_custom_annotations(self, annotation_type, f):
+    def _process_custom_annotations(self, annotation_type, processor):
         # type: (typing.Type[T], typing.Callable[[T, U], U]) -> None
         pass
 
@@ -73,7 +73,7 @@ class Union(object):
     def __hash__(self):
         return hash((self._tag, self._value))
 
-    def _process_custom_annotations(self, annotation_type, f):
+    def _process_custom_annotations(self, annotation_type, processor):
         # type: (typing.Type[T], typing.Callable[[T, U], U]) -> None
         pass
 
@@ -129,24 +129,24 @@ class Route(object):
 # put this here so that every other file doesn't need to import functools
 partially_apply = functools.partial
 
-def make_struct_annotation_processor(annotation_type, f):
+def make_struct_annotation_processor(annotation_type, processor):
     def g(struct):
         if struct is None:
             return struct
-        struct._process_custom_annotations(annotation_type, f)
+        struct._process_custom_annotations(annotation_type, processor)
         return struct
     return g
 
-def make_list_annotation_processor(f):
+def make_list_annotation_processor(processor):
     def g(list_):
         if list_ is None:
             return list_
-        return [f(x) for x in list_]
+        return [processor(x) for x in list_]
     return g
 
-def make_map_value_annotation_processor(f):
+def make_map_value_annotation_processor(processor):
     def g(map_):
         if map_ is None:
             return map_
-        return {k: f(v) for k, v in map_.items()}
+        return {k: processor(v) for k, v in map_.items()}
     return g

--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -376,7 +376,7 @@ class PythonTypeStubsBackend(CodeBackend):
         with self.indent():
             self.emit('self,')
             self.emit('annotation_type: Type[T],')
-            self.emit('f: Callable[[T, U], U],')
+            self.emit('processor: Callable[[T, U], U],')
             self.import_tracker._register_typing_import('Type')
             self.import_tracker._register_typing_import('Callable')
         self.emit(') -> None: ...')

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -269,7 +269,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             Struct1_validator: bv.Validator = ...
@@ -312,7 +312,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             Struct2_validator: bv.Validator = ...
@@ -365,7 +365,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             NestedTypes_validator: bv.Validator = ...
@@ -399,7 +399,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             Union_validator: bv.Validator = ...
@@ -419,7 +419,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             Shape_validator: bv.Validator = ...
@@ -444,7 +444,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             EmptyUnion_validator: bv.Validator = ...
@@ -508,7 +508,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    f: Callable[[T, U], U],
+                    processor: Callable[[T, U], U],
                 ) -> None: ...
 
             Struct1_validator: bv.Validator = ...

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -204,9 +204,11 @@ class TestGeneratedPythonTypes(unittest.TestCase):
                     self._unannotated_field_value = None
                     self._unannotated_field_present = False
 
-                def _process_custom_annotations(self, annotation_type, f):
+                def _process_custom_annotations(self, annotation_type, processor):
+                    super(MyStruct, self)._process_custom_annotations(annotation_type, processor)
+
                     if annotation_type is MyAnnotationType:
-                        self.annotated_field = bb.partially_apply(f, MyAnnotationType(test_param=42))(self.annotated_field)
+                        self.annotated_field = bb.partially_apply(processor, MyAnnotationType(test_param=42))(self.annotated_field)
 
                 def __repr__(self):
                     return 'MyStruct(annotated_field={!r}, unannotated_field={!r})'.format(


### PR DESCRIPTION
Changes naming of `f` function argument to `processor` in `_process_custom_annotations` to match documentation and has `_process_custom_annotations` call its base class version in all cases.