### PR TITLE
Fix aliases not being fully resolved by compiler (with regression fix).

### DIFF
--- a/stone/backend.py
+++ b/stone/backend.py
@@ -55,12 +55,18 @@ def remove_aliases_from_api(api):
             for field in data_type.fields:
                 strip_alias(field)
         for route in namespace.routes:
+            # Strip inner aliases
+            strip_alias(route.arg_data_type)
+            strip_alias(route.result_data_type)
+            strip_alias(route.error_data_type)
+
+            # Strip top-level aliases
             if is_alias(route.arg_data_type):
-                strip_alias(route.arg_data_type)
+                route.arg_data_type = route.arg_data_type.data_type
             if is_alias(route.result_data_type):
-                strip_alias(route.result_data_type)
+                route.result_data_type = route.result_data_type.data_type
             if is_alias(route.error_data_type):
-                strip_alias(route.error_data_type)
+                route.error_data_type = route.error_data_type.data_type
 
         # Clear aliases
         namespace.aliases = []

--- a/stone/backend.py
+++ b/stone/backend.py
@@ -9,6 +9,7 @@ import textwrap
 from stone.frontend.ir_generator import doc_ref_re
 from stone.ir import (
     is_alias,
+    resolve_aliases
 )
 
 _MYPY = False
@@ -40,29 +41,12 @@ def remove_aliases_from_api(api):
         # Remove nested aliases first. This way, when we replace an alias with
         # its source later on, it too is alias free.
         for alias in namespace.aliases:
-            data_type = alias
-            while True:
-                # For better or for worse, all non-user-defined types that
-                # reference other types do so with a 'data_type' attribute.
-                if hasattr(data_type, 'data_type'):
-                    if is_alias(data_type.data_type):
-                        # Skip the alias (this looks so terrible...)
-                        data_type.data_type = data_type.data_type.data_type
-                    data_type = data_type.data_type
-                else:
-                    break
-
+            alias.data_type = resolve_aliases(alias.data_type)
         for data_type in namespace.data_types:
             for field in data_type.fields:
-                data_type = field
-                while True:
-                    if hasattr(data_type, 'data_type'):
-                        if is_alias(data_type.data_type):
-                            data_type.data_type = data_type.data_type.data_type
-                        data_type = data_type.data_type
-                    else:
-                        break
-
+                # Unwrap alias for field
+                if is_alias(field.data_type):
+                    field.data_type = field.data_type.data_type
         for route in namespace.routes:
             if is_alias(route.arg_data_type):
                 route.arg_data_type = route.arg_data_type.data_type

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1954,6 +1954,28 @@ def resolve_aliases(data_type):
 
     return resolved
 
+def strip_alias(data_type):
+    """
+    Strip alias from a data_type chain - this function should be
+    used *after* aliases are resolved (see resolve_aliases fn):
+
+    Loops through given data type chain (unwraps types), replaces
+    first alias with underlying type, and then terminates.
+
+    Note: Stops on encountering the first alias as it assumes
+    intermediate aliases are already removed.
+
+    Args:
+        data_type (DataType): The target DataType chain to strip.
+    Return:
+        None
+    """
+    while hasattr(data_type, 'data_type'):
+        if is_alias(data_type.data_type):
+            data_type.data_type = data_type.data_type.data_type
+            break
+        data_type = data_type.data_type
+
 def unwrap(data_type):
     """
     Convenience method to unwrap all Aliases and Nullables from around a

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1935,7 +1935,7 @@ def unwrap_aliases(data_type):
 
 def resolve_aliases(data_type):
     """
-    Resolve all chained / nested Aliases - this will recursively point
+    Resolve all chained / nested aliases. This will recursively point
     nested aliases to their resolved data type (first non-alias in the chain).
 
     Note: This differs from unwrap_alias which simply identifies/returns

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -1933,6 +1933,26 @@ def unwrap_aliases(data_type):
         data_type = data_type.data_type
     return data_type, unwrapped_alias
 
+def resolve_aliases(data_type):
+    """
+    Resolve all chained / nested Aliases - this will recursively point
+    nested aliases to their resolved data type (first non-alias in the chain).
+
+    Note: This differs from unwrap_alias which simply identifies/returns
+    the resolved data type.
+
+    Args:
+        data_type (DataType): The target DataType/Alias to resolve.
+    Return:
+        DataType: The resolved type.
+    """
+    if not is_alias(data_type):
+        return data_type
+
+    resolved = resolve_aliases(data_type.data_type)
+    data_type.data_type = resolved
+
+    return resolved
 
 def unwrap(data_type):
     """

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -17,7 +17,8 @@ from stone.ir import (
     StructField,
     Union,
     UnionField,
-    resolve_aliases
+    resolve_aliases,
+    strip_alias
 )
 from stone.backend import (
     remove_aliases_from_api,
@@ -256,11 +257,47 @@ int sq(int x) <
         self.assertIsInstance(first_alias.data_type, String)
         self.assertIsInstance(second_alias.data_type, String)
 
+    def test_strip_alias(self):
+        first_alias = Alias(None, None, None)
+        second_alias = Alias(None, None, None)
+        third_alias = Alias(None, None, None)
+        first_alias.data_type = second_alias
+        second_alias.data_type = third_alias
+        third_alias.data_type = String()
+
+        test_struct = Struct('TestStruct', None, None)
+        test_struct.set_attributes(None, [
+            StructField('field1', List(Nullable(first_alias)), None, None)
+        ])
+
+        curr_type = first_alias
+        while hasattr(curr_type, 'data_type'):
+            curr_type.data_type = resolve_aliases(curr_type.data_type)
+            curr_type = curr_type.data_type
+
+        self.assertIsInstance(first_alias.data_type, String)
+
+        self.assertEqual(len(test_struct.fields), 1)
+        field = test_struct.fields[0]
+
+        strip_alias(field.data_type)
+
+        list_type = field.data_type
+        self.assertIsInstance(list_type, List)
+        nullable_type = list_type.data_type
+        self.assertIsInstance(nullable_type, Nullable)
+        string_type = nullable_type.data_type
+        self.assertIsInstance(string_type, String)
+
     def test_preserve_aliases_from_api(self):
         api = Api(version=None)
+        # Ensure imports come after 'preserve_alias' lexiographicaly
+        # to catch namespace ordering bugs
         api.ensure_namespace('preserve_alias')
+        api.ensure_namespace('zzzz')
 
         ns = api.namespaces['preserve_alias']
+        imported = api.namespaces['zzzz']
 
         namespace_id = Alias('NamespaceId', ns, None)
         namespace_id.data_type = String()
@@ -268,18 +305,29 @@ int sq(int x) <
         shared_folder_id.set_attributes(None, namespace_id)
         path_root_id = Alias('PathRootId', ns, None)
         path_root_id.set_attributes(None, shared_folder_id)
+        foo_alias = Alias('FooAlias', None, None)
+        foo_alias.set_attributes(None, String())
+        bar_alias = Alias('BarAlias', None, None)
+        bar_alias.set_attributes(None, foo_alias)
 
         ns.add_alias(namespace_id)
         ns.add_alias(shared_folder_id)
         ns.add_alias(path_root_id)
+        imported.add_alias(foo_alias)
+        imported.add_alias(bar_alias)
 
         test_struct = Struct('TestStruct', ns, None)
         test_struct.set_attributes(None, [StructField('field1', path_root_id, None, None)])
         test_union = Union('TestUnion', ns, None, None)
         test_union.set_attributes(None, [UnionField('test', path_root_id, None, None)])
+        dependent_struct = Struct('DependentStruct', ns, None)
+        dependent_struct.set_attributes(None, [
+            StructField('field_alias', imported.alias_by_name['BarAlias'], None, None)
+        ])
 
         ns.add_data_type(test_struct)
         ns.add_data_type(test_union)
+        ns.add_data_type(dependent_struct)
 
         struct_alias = Alias('StructAlias', ns, None)
         struct_alias.set_attributes(None, test_struct)
@@ -287,13 +335,22 @@ int sq(int x) <
         ns.add_alias(struct_alias)
 
         # Ensure namespace exists
-        self.assertEqual(len(api.namespaces), 1)
+        self.assertEqual(len(api.namespaces), 2)
         self.assertTrue('preserve_alias' in api.namespaces)
+        self.assertTrue('zzzz' in api.namespaces)
 
         ns = api.namespaces['preserve_alias']
+        imported = api.namespaces['zzzz']
+
+        # Ensure aliases exist
+        self.assertEqual(len(ns.aliases), 4)
+        self.assertEqual(len(imported.aliases), 2)
 
         aliases = {
             alias._name: alias for alias in ns.aliases
+        }
+        imported_aliases = {
+            alias.name: alias for alias in imported.aliases
         }
         data_types = {
             data_type._name: data_type for data_type in ns.data_types
@@ -304,22 +361,32 @@ int sq(int x) <
         self.assertTrue('SharedFolderId' in aliases)
         self.assertTrue('PathRootId' in aliases)
         self.assertTrue('StructAlias' in aliases)
+        self.assertTrue('FooAlias' in imported_aliases)
+        self.assertTrue('BarAlias' in imported_aliases)
 
         # Ensure aliases resolve to proper types
         self.assertIsInstance(aliases['NamespaceId'].data_type, String)
         self.assertIsInstance(aliases['SharedFolderId'].data_type, Alias)
         self.assertIsInstance(aliases['PathRootId'].data_type, Alias)
         self.assertIsInstance(aliases['StructAlias'].data_type, Struct)
+        self.assertIsInstance(imported_aliases['FooAlias'].data_type, String)
+        self.assertIsInstance(imported_aliases['BarAlias'].data_type, Alias)
 
         # Ensure struct and union field aliases resolve to proper types
         self.assertIsInstance(data_types['TestStruct'], Struct)
 
         test_struct = data_types.get('TestStruct')
+        dependent_struct = data_types.get('DependentStruct')
 
         self.assertTrue(len(test_struct.fields), 1)
+        self.assertTrue(len(dependent_struct.fields), 1)
 
         field = test_struct.fields[0]
         self.assertEqual(field.name, 'field1')
+        self.assertIsInstance(field.data_type, Alias)
+
+        field = dependent_struct.fields[0]
+        self.assertEqual(field.name, 'field_alias')
         self.assertIsInstance(field.data_type, Alias)
 
         test_union = data_types['TestUnion']
@@ -332,10 +399,15 @@ int sq(int x) <
 
     def test_no_preserve_aliases_from_api(self):
         api = Api(version=None)
+        # Ensure imports come after 'preserve_alias' lexiographicaly
+        # to catch namespace ordering bugs
         api.ensure_namespace('preserve_alias')
+        api.ensure_namespace('zzzz')
 
         ns = api.namespaces['preserve_alias']
+        imported = api.namespaces['zzzz']
 
+        # Setup aliases
         namespace_id = Alias('NamespaceId', ns, None)
         namespace_id.data_type = String()
         shared_folder_id = Alias('SharedFolderId', ns, None)
@@ -344,12 +416,19 @@ int sq(int x) <
         path_root_id.set_attributes(None, shared_folder_id)
         nullable_alias = Alias('NullableAlias', ns, None)
         nullable_alias.set_attributes(None, Nullable(path_root_id))
+        foo_alias = Alias('FooAlias', None, None)
+        foo_alias.set_attributes(None, String())
+        bar_alias = Alias('BarAlias', None, None)
+        bar_alias.set_attributes(None, foo_alias)
 
         ns.add_alias(namespace_id)
         ns.add_alias(shared_folder_id)
         ns.add_alias(path_root_id)
         ns.add_alias(nullable_alias)
+        imported.add_alias(foo_alias)
+        imported.add_alias(bar_alias)
 
+        # Setup composite types
         test_struct = Struct('TestStruct', ns, None)
         test_struct.set_attributes(None, [
             StructField('field_alias', path_root_id, None, None),
@@ -358,10 +437,16 @@ int sq(int x) <
         ])
         test_union = Union('TestUnion', ns, None, None)
         test_union.set_attributes(None, [UnionField('test', path_root_id, None, None)])
+        dependent_struct = Struct('DependentStruct', ns, None)
+        dependent_struct.set_attributes(None, [
+            StructField('field_alias', imported.alias_by_name['BarAlias'], None, None)
+        ])
 
         ns.add_data_type(test_struct)
         ns.add_data_type(test_union)
+        ns.add_data_type(dependent_struct)
 
+        # Setup aliases on composite types
         struct_alias = Alias('StructAlias', ns, None)
         struct_alias.set_attributes(None, test_struct)
 
@@ -370,13 +455,16 @@ int sq(int x) <
         api = remove_aliases_from_api(api)
 
         # Ensure namespace exists
-        self.assertEqual(len(api.namespaces), 1)
+        self.assertEqual(len(api.namespaces), 2)
         self.assertTrue('preserve_alias' in api.namespaces)
+        self.assertTrue('zzzz' in api.namespaces)
 
         ns = api.namespaces['preserve_alias']
+        imported = api.namespaces['zzzz']
 
         # Ensure aliases are gone
         self.assertEqual(len(ns.aliases), 0)
+        self.assertEqual(len(imported.aliases), 0)
 
         data_types = {
             data_type._name: data_type for data_type in ns.data_types
@@ -406,6 +494,15 @@ int sq(int x) <
         field = test_union.fields[0]
 
         self.assertEqual(field.name, 'test')
+        self.assertIsInstance(field.data_type, String)
+
+        # Ensure struct using imported alias resolves properly
+        dependent_struct = data_types.get('DependentStruct')
+        self.assertIsInstance(dependent_struct, Struct)
+
+        self.assertEqual(len(dependent_struct.fields), 1)
+
+        field = dependent_struct.fields[0]
         self.assertIsInstance(field.data_type, String)
 
 if __name__ == '__main__':

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from stone.ir import (
+    Alias,
+    Api,
     ApiNamespace,
     ApiRoute,
     List,
@@ -12,8 +14,14 @@ from stone.ir import (
     String,
     Struct,
     StructField,
+    Union,
+    UnionField,
+    resolve_aliases
 )
-from stone.backend import CodeBackend
+from stone.backend import (
+    remove_aliases_from_api,
+    CodeBackend
+)
 
 _MYPY = False
 if _MYPY:
@@ -225,6 +233,164 @@ int sq(int x) <
         t = _TesterCmdline(None, ['-v'])
         self.assertTrue(t.args.verbose)
 
+    def test_resolve_aliases(self):
+        first_alias = Alias(None, None, None)
+        first_alias.data_type = String()
+        resolved_type = resolve_aliases(first_alias.data_type)
+
+        # Test that single-level alias chain resolves
+        self.assertIsInstance(resolved_type, String)
+        self.assertIsInstance(first_alias.data_type, String)
+
+        first_alias = Alias(None, None, None)
+        second_alias = Alias(None, None, None)
+        first_alias.data_type = second_alias
+        second_alias.data_type = String()
+
+        # Test that a two-level alias chain resolves
+        resolved_type = resolve_aliases(first_alias.data_type)
+        first_alias.data_type = resolved_type
+
+        self.assertIsInstance(resolved_type, String)
+        self.assertIsInstance(first_alias.data_type, String)
+        self.assertIsInstance(second_alias.data_type, String)
+
+    def test_preserve_aliases_from_api(self):
+        api = Api(version=None)
+        api.ensure_namespace('preserve_alias')
+
+        ns = api.namespaces['preserve_alias']
+
+        namespace_id = Alias('NamespaceId', ns, None)
+        namespace_id.data_type = String()
+        shared_folder_id = Alias('SharedFolderId', ns, None)
+        shared_folder_id.set_attributes(None, namespace_id)
+        path_root_id = Alias('PathRootId', ns, None)
+        path_root_id.set_attributes(None, shared_folder_id)
+
+        ns.add_alias(namespace_id)
+        ns.add_alias(shared_folder_id)
+        ns.add_alias(path_root_id)
+
+        test_struct = Struct('TestStruct', ns, None)
+        test_struct.set_attributes(None, [StructField('field1', path_root_id, None, None)])
+        test_union = Union('TestUnion', ns, None, None)
+        test_union.set_attributes(None, [UnionField('test', path_root_id, None, None)])
+
+        ns.add_data_type(test_struct)
+        ns.add_data_type(test_union)
+
+        struct_alias = Alias('StructAlias', ns, None)
+        struct_alias.set_attributes(None, test_struct)
+
+        ns.add_alias(struct_alias)
+
+        # Ensure namespace exists
+        self.assertEqual(len(api.namespaces), 1)
+        self.assertTrue('preserve_alias' in api.namespaces)
+
+        ns = api.namespaces['preserve_alias']
+
+        aliases = {
+            alias._name: alias for alias in ns.aliases
+        }
+        data_types = {
+            data_type._name: data_type for data_type in ns.data_types
+        }
+
+        # Ensure aliases are in the namespace
+        self.assertTrue('NamespaceId' in aliases)
+        self.assertTrue('SharedFolderId' in aliases)
+        self.assertTrue('PathRootId' in aliases)
+        self.assertTrue('StructAlias' in aliases)
+
+        # Ensure aliases resolve to proper types
+        self.assertIsInstance(aliases['NamespaceId'].data_type, String)
+        self.assertIsInstance(aliases['SharedFolderId'].data_type, Alias)
+        self.assertIsInstance(aliases['PathRootId'].data_type, Alias)
+        self.assertIsInstance(aliases['StructAlias'].data_type, Struct)
+
+        # Ensure struct and union field aliases resolve to proper types
+        self.assertIsInstance(data_types['TestStruct'], Struct)
+
+        test_struct = data_types.get('TestStruct')
+
+        self.assertTrue(len(test_struct.fields), 1)
+
+        field = test_struct.fields[0]
+        self.assertEqual(field.name, 'field1')
+        self.assertIsInstance(field.data_type, Alias)
+
+        test_union = data_types['TestUnion']
+
+        self.assertTrue(len(test_union.fields), 1)
+        field = test_union.fields[0]
+
+        self.assertEqual(field.name, 'test')
+        self.assertIsInstance(field.data_type, Alias)
+
+    def test_no_preserve_aliases_from_api(self):
+        api = Api(version=None)
+        api.ensure_namespace('preserve_alias')
+
+        ns = api.namespaces['preserve_alias']
+
+        namespace_id = Alias('NamespaceId', ns, None)
+        namespace_id.data_type = String()
+        shared_folder_id = Alias('SharedFolderId', ns, None)
+        shared_folder_id.set_attributes(None, namespace_id)
+        path_root_id = Alias('PathRootId', ns, None)
+        path_root_id.set_attributes(None, shared_folder_id)
+
+        ns.add_alias(namespace_id)
+        ns.add_alias(shared_folder_id)
+        ns.add_alias(path_root_id)
+
+        test_struct = Struct('TestStruct', ns, None)
+        test_struct.set_attributes(None, [StructField('field1', path_root_id, None, None)])
+        test_union = Union('TestUnion', ns, None, None)
+        test_union.set_attributes(None, [UnionField('test', path_root_id, None, None)])
+
+        ns.add_data_type(test_struct)
+        ns.add_data_type(test_union)
+
+        struct_alias = Alias('StructAlias', ns, None)
+        struct_alias.set_attributes(None, test_struct)
+
+        ns.add_alias(struct_alias)
+
+        api = remove_aliases_from_api(api)
+
+        # Ensure namespace exists
+        self.assertEqual(len(api.namespaces), 1)
+        self.assertTrue('preserve_alias' in api.namespaces)
+
+        ns = api.namespaces['preserve_alias']
+
+        # Ensure aliases are gone
+        self.assertEqual(len(ns.aliases), 0)
+
+        data_types = {
+            data_type._name: data_type for data_type in ns.data_types
+        }
+
+        # Ensure struct and union field aliases resolve to proper types
+        test_struct = data_types.get('TestStruct')
+        self.assertIsInstance(test_struct, Struct)
+
+        self.assertTrue(len(test_struct.fields), 1)
+
+        field = test_struct.fields[0]
+        self.assertEqual(field.name, 'field1')
+        self.assertIsInstance(field.data_type, String)
+
+        test_union = data_types['TestUnion']
+
+        self.assertTrue(len(test_union.fields), 1)
+        field = test_union.fields[0]
+
+        self.assertEqual(field.name, 'test')
+        self.assertIsInstance(field.data_type, String)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Summary:

Pranay recently noticed a regression in the Swift backend where generated code was being polluted with alias types. I reverted my change for the alias bug (as it seemed to the cause of the problem) and after investigating it seems I overlooked some logic which was actually pretty key to properly resolving some data type chains.

More specifically I accidentally removed logic that (implicitly) handled composite types (e.g. Lists, Nullables, etc.) being in an alias/field type chain - I ended up restoring some stuff we removed and left more detailed comments which (hopefully) will make the functionality of the code more clear. I also added test coverage which will prevent a regression of this type from getting released.

Resolves T158219.

Note: I cherry-picked the original (squashed) commit and made a new commit adding additional fixes. The second commit is the most useful diff for the new changes / fixes for the regression.