### PR TITLE
Fix generating swift and objc types when running with Python 3.x

### DIFF
--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -909,8 +909,8 @@ class ObjCTypesBackend(ObjCBaseBackend):
                     ]))
         elif is_string_type(data_type):
             if data_type.pattern or data_type.min_length or data_type.max_length:
-                pattern = data_type.pattern.encode('unicode_escape').replace(
-                    "\"", "\\\"") if data_type.pattern else None
+                pat = data_type.pattern if data_type.pattern else None
+                pat = pat.replace("\\", "\\\\").replace("\"", "\\\"") if pat else pat
                 validator = '{}:{}'.format(
                     fmt_validator(data_type),
                     fmt_func_args([
@@ -918,8 +918,8 @@ class ObjCTypesBackend(ObjCBaseBackend):
                          if data_type.min_length else 'nil'),
                         ('maxLength', '@({})'.format(data_type.max_length)
                          if data_type.max_length else 'nil'),
-                        ('pattern', '@"{}"'.format(pattern)
-                         if pattern else 'nil'),
+                        ('pattern', '@"{}"'.format(pat)
+                         if pat else 'nil'),
                     ]))
 
         if nullable:

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -235,7 +235,7 @@ class SwiftTypesBackend(SwiftBaseBackend):
             )
         elif is_string_type(data_type):
             pat = data_type.pattern if data_type.pattern else None
-            pat = pat.encode('unicode_escape').replace("\"", "\\\"") if pat else pat
+            pat = pat.replace("\\", "\\\\").replace("\"", "\\\"") if pat else pat
             v = "stringValidator({})".format(
                 self._func_args([
                     ("minLength", data_type.min_length),


### PR DESCRIPTION
- Previously, trying to generate swift of objc types failed if your system python was 3.x, eg:
   > python -m stone.cli -a host -a style swift_types ...
  would yield this error:
  > TypeError: a bytes-like object is required, not 'str'
- The root cause is that the result of encode() is a bytes-like object, not a string, and the
  code is trying to replace strings within that bytes-like object
- This isn't an issue in python2's version of strings, only 3's
- Fixed by just replacing the characters that need escaping (quote and backslash) instead of trying to encode
- This approach produces identical output to the previous for all current stone files under
  both python2 and python3 environments