### PR TITLE
Fix name used to refer to alias validator in Python backend

### DIFF
--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -1169,7 +1169,7 @@ def generate_validator_constructor(ns, data_type):
             v = '{}.{}'.format(fmt_namespace(dt.namespace.name), v)
     elif is_alias(dt):
         # Assume that the alias has already been declared elsewhere.
-        name = fmt_class(dt.name) + '_validator'
+        name = dt.name + '_validator'
         if ns.name != dt.namespace.name:
             name = '{}.{}'.format(fmt_namespace(dt.namespace.name), name)
         v = name


### PR DESCRIPTION
This changes references to the validator for an alias to use the alias name instead of its name formatted as a class.

Alias validators are declared [here](https://github.com/dropbox/stone/blob/master/stone/backends/python_types.py#L177) using `alias.name`, while they are referred to later as `fmt_class(alias.name)` in the Python backend. This mismatch causes a NameError when importing the generated file if the alias name isn't the same as the class name format.

