### PR TITLE
Fix regression for namespaced fields

### DIFF
--- a/stone/backends/python_type_mapping.py
+++ b/stone/backends/python_type_mapping.py
@@ -74,8 +74,11 @@ def map_stone_type_to_python_type(ns, data_type, override_dict=None):
     elif is_user_defined_type(data_type):
         user_defined_type = cast(UserDefined, data_type)
         class_name = class_name_for_data_type(user_defined_type)
-        return '{}.{}'.format(
-            fmt_namespace(user_defined_type.namespace.name), class_name)
+        if user_defined_type.namespace.name != ns.name:
+            return '{}.{}'.format(
+                fmt_namespace(user_defined_type.namespace.name), class_name)
+        else:
+            return class_name
     elif is_list_type(data_type):
         list_type = cast(List, data_type)
         if List in override_dict:

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -845,9 +845,13 @@ class PythonTypesBackend(CodeBackend):
                         fmt_namespaced_var(ns.name, data_type.name, field.name),
                         self.process_doc(field.doc, self._docf))
                 elif is_user_defined_type(field.data_type):
+                    if data_type.namespace.name != ns.name:
+                        formatted_var = fmt_namespaced_var(ns.name, data_type.name, field.name)
+                    else:
+                        formatted_var = '{}.{}'.format(data_type.name, fmt_var(field.name))
                     ivar_doc = ':ivar {} {}: {}'.format(
                         fmt_class(field.data_type.name),
-                        fmt_namespaced_var(ns.name, data_type.name, field.name),
+                        formatted_var,
                         self.process_doc(field.doc, self._docf))
                 else:
                     ivar_doc = ':ivar {} {}: {}'.format(


### PR DESCRIPTION
A regression was introduced in 
https://github.com/dropbox/stone/commit/0c4b720cc9377314da9850513315d28144b3285d
where the name of user-defined types did not consider whether the namespace of the type is the same as the current namespace, in which case the namespace can be omitted.