### PR TITLE
Fix typo in backend_ref.rst.

### DIFF
--- a/docs/backend_ref.rst
+++ b/docs/backend_ref.rst
@@ -175,7 +175,7 @@ doc
 arg_data_type
     A DataType object of the arg to the route.
 
-arg_data_type
+result_data_type
     A DataType object of the result of the route.
 
 error_data_type


### PR DESCRIPTION
The DataType object of the result of a route is called `result_arg_type`.