### PR TITLE
Add field path to custom annotations processing

### DIFF
--- a/docs/lang_ref.rst
+++ b/docs/lang_ref.rst
@@ -937,19 +937,20 @@ order fields are listed in the custom annotation definition.
 
 
 In client code, you can access every field of a struct marked with a certain
-custom annotation by calling ``._process_custom_annotations(custom_annotation,
-processor)`` on the struct. ``processor`` will then be called with two
-parameters---an instance of the annotation type with all the parameters
-populated and the value of the field. The value of the field will then be
-replaced with the return value of ``processor``.
+custom annotation by calling ``._process_custom_annotations(custom_annotation, context,
+processor)`` on the struct. ``processor`` will then be called with three
+parameters: (1) an instance of the annotation type with all the parameters
+populated, (2) a string containing the context in which the field is being
+evaluated (i.e., for debugging purposes), and (3) the value of the field.
+The value of the field will then be replaced with the return value of ``processor``.
 
 Note that this will also affect annotated fields that are located arbitrarily
 deep in the struct. In the example above, if ``secret`` is a struct of type
-``Secrets``, then calling ``secret._process_custom_annotations(Noteworthy, processor)``
+``Secrets``, then calling ``secret._process_custom_annotations(Noteworthy, "Secrets", processor)``
 will result in ``processor`` being called once as
-``processor(Noteworthy("low"), secret.small_secret)`` and once as
-``processor(Noteworthy("high"), x)`` for each element ``x`` of
-``secret.lots_of_big_ones``.
+``processor(Noteworthy("low"), "Secrets.small_secret", secret.small_secret)`` and once as
+``processor(Noteworthy("high"), "Secrets.lots_of_big_ones[i]", x)`` for each element ``x`` at
+index ``i`` of ``secret.lots_of_big_ones``.
 
 .. _doc:
 

--- a/docs/lang_ref.rst
+++ b/docs/lang_ref.rst
@@ -937,11 +937,11 @@ order fields are listed in the custom annotation definition.
 
 
 In client code, you can access every field of a struct marked with a certain
-custom annotation by calling ``._process_custom_annotations(custom_annotation, context,
+custom annotation by calling ``._process_custom_annotations(custom_annotation, field_path,
 processor)`` on the struct. ``processor`` will then be called with three
 parameters: (1) an instance of the annotation type with all the parameters
-populated, (2) a string containing the context in which the field is being
-evaluated (i.e., for debugging purposes), and (3) the value of the field.
+populated, (2) a string denoting the path to the field being evaluated
+(i.e., for debugging purposes), and (3) the value of the field.
 The value of the field will then be replaced with the return value of ``processor``.
 
 Note that this will also affect annotated fields that are located arbitrarily

--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -31,8 +31,8 @@ if _MYPY:
 
 class Struct(object):
     # This is a base class for all classes representing Stone structs.
-    def _process_custom_annotations(self, annotation_type, processor):
-        # type: (typing.Type[T], typing.Callable[[T, U], U]) -> None
+    def _process_custom_annotations(self, annotation_type, context, processor):
+        # type: (typing.Type[T], typing.Text, typing.Callable[[T, U], U]) -> None
         pass
 
 class Union(object):
@@ -73,8 +73,8 @@ class Union(object):
     def __hash__(self):
         return hash((self._tag, self._value))
 
-    def _process_custom_annotations(self, annotation_type, processor):
-        # type: (typing.Type[T], typing.Callable[[T, U], U]) -> None
+    def _process_custom_annotations(self, annotation_type, context, processor):
+        # type: (typing.Type[T], typing.Text, typing.Callable[[T, U], U]) -> None
         pass
 
     @classmethod
@@ -130,23 +130,23 @@ class Route(object):
 partially_apply = functools.partial
 
 def make_struct_annotation_processor(annotation_type, processor):
-    def g(struct):
+    def g(context, struct):
         if struct is None:
             return struct
-        struct._process_custom_annotations(annotation_type, processor)
+        struct._process_custom_annotations(annotation_type, context, processor)
         return struct
     return g
 
 def make_list_annotation_processor(processor):
-    def g(list_):
+    def g(context, list_):
         if list_ is None:
             return list_
-        return [processor(x) for x in list_]
+        return [processor('{}[{}]'.format(context, idx), x) for idx, x in enumerate(list_)]
     return g
 
 def make_map_value_annotation_processor(processor):
-    def g(map_):
+    def g(context, map_):
         if map_ is None:
             return map_
-        return {k: processor(v) for k, v in map_.items()}
+        return {k: processor('{}[{}]'.format(context, repr(k)), v) for k, v in map_.items()}
     return g

--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -31,7 +31,7 @@ if _MYPY:
 
 class Struct(object):
     # This is a base class for all classes representing Stone structs.
-    def _process_custom_annotations(self, annotation_type, context, processor):
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
         # type: (typing.Type[T], typing.Text, typing.Callable[[T, U], U]) -> None
         pass
 
@@ -73,7 +73,7 @@ class Union(object):
     def __hash__(self):
         return hash((self._tag, self._value))
 
-    def _process_custom_annotations(self, annotation_type, context, processor):
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
         # type: (typing.Type[T], typing.Text, typing.Callable[[T, U], U]) -> None
         pass
 
@@ -130,23 +130,23 @@ class Route(object):
 partially_apply = functools.partial
 
 def make_struct_annotation_processor(annotation_type, processor):
-    def g(context, struct):
+    def g(field_path, struct):
         if struct is None:
             return struct
-        struct._process_custom_annotations(annotation_type, context, processor)
+        struct._process_custom_annotations(annotation_type, field_path, processor)
         return struct
     return g
 
 def make_list_annotation_processor(processor):
-    def g(context, list_):
+    def g(field_path, list_):
         if list_ is None:
             return list_
-        return [processor('{}[{}]'.format(context, idx), x) for idx, x in enumerate(list_)]
+        return [processor('{}[{}]'.format(field_path, idx), x) for idx, x in enumerate(list_)]
     return g
 
 def make_map_value_annotation_processor(processor):
-    def g(context, map_):
+    def g(field_path, map_):
         if map_ is None:
             return map_
-        return {k: processor('{}[{}]'.format(context, repr(k)), v) for k, v in map_.items()}
+        return {k: processor('{}[{}]'.format(field_path, repr(k)), v) for k, v in map_.items()}
     return g

--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -382,8 +382,10 @@ class PythonTypeStubsBackend(CodeBackend):
         with self.indent():
             self.emit('self,')
             self.emit('annotation_type: Type[T],')
+            self.emit('context: Text,')
             self.emit('processor: Callable[[T, U], U],')
             self.import_tracker._register_typing_import('Type')
+            self.import_tracker._register_typing_import('Text')
             self.import_tracker._register_typing_import('Callable')
         self.emit(') -> None: ...')
         self.emit()

--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -382,7 +382,7 @@ class PythonTypeStubsBackend(CodeBackend):
         with self.indent():
             self.emit('self,')
             self.emit('annotation_type: Type[T],')
-            self.emit('context: Text,')
+            self.emit('field_path: Text,')
             self.emit('processor: Callable[[T, U], U],')
             self.import_tracker._register_typing_import('Type')
             self.import_tracker._register_typing_import('Text')

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -717,13 +717,12 @@ class PythonTypesBackend(CodeBackend):
         The _process_custom_annotations function allows client code to access
         custom annotations defined in the spec.
         """
-        self.emit('def _process_custom_annotations(self, annotation_type, processor):')
+        self.emit('def _process_custom_annotations(self, annotation_type, context, processor):')
 
         with self.indent(), emit_pass_if_nothing_emitted(self):
             self.emit(
-                'super({}, self)._process_custom_annotations(annotation_type, processor)'.format(
-                    class_name_for_data_type(data_type)
-                )
+                ('super({}, self)._process_custom_annotations(annotation_type, context, processor)'
+                ).format(class_name_for_data_type(data_type))
             )
             self.emit()
 
@@ -736,7 +735,12 @@ class PythonTypesBackend(CodeBackend):
                     with self.indent():
                         self.emit('self.{} = {}'.format(
                             field_name,
-                            generate_func_call(processor, args=['self.{}'.format(field_name)])
+                            generate_func_call(
+                                processor,
+                                args=[
+                                    "'{{}}.{}'.format(context)".format(field_name),
+                                    'self.{}'.format(field_name),
+                                ])
                         ))
                     self.emit()
 
@@ -1027,12 +1031,11 @@ class PythonTypesBackend(CodeBackend):
         The _process_custom_annotations function allows client code to access
         custom annotations defined in the spec.
         """
-        self.emit('def _process_custom_annotations(self, annotation_type, processor):')
+        self.emit('def _process_custom_annotations(self, annotation_type, context, processor):')
         with self.indent(), emit_pass_if_nothing_emitted(self):
             self.emit(
-                'super({}, self)._process_custom_annotations(annotation_type, processor)'.format(
-                    class_name_for_data_type(data_type)
-                )
+                ('super({}, self)._process_custom_annotations(annotation_type, context, processor)'
+                 ).format(class_name_for_data_type(data_type))
             )
             self.emit()
 
@@ -1053,7 +1056,12 @@ class PythonTypesBackend(CodeBackend):
                         self.emit('if annotation_type is {}:'.format(annotation_class))
                         with self.indent():
                             self.emit('self._value = {}'.format(
-                                generate_func_call(processor, args=['self._value'])
+                                generate_func_call(
+                                    processor,
+                                    args=[
+                                        "'{{}}.{}'.format(context)".format(field_name),
+                                        'self._value',
+                                    ])
                             ))
                         self.emit()
 

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -721,7 +721,9 @@ class PythonTypesBackend(CodeBackend):
 
         with self.indent(), emit_pass_if_nothing_emitted(self):
             self.emit(
-                ('super({}, self)._process_custom_annotations(annotation_type, context, processor)'
+                (
+                    'super({}, self)._process_custom_annotations(annotation_type, context, '
+                    'processor)'
                 ).format(class_name_for_data_type(data_type))
             )
             self.emit()
@@ -1034,8 +1036,10 @@ class PythonTypesBackend(CodeBackend):
         self.emit('def _process_custom_annotations(self, annotation_type, context, processor):')
         with self.indent(), emit_pass_if_nothing_emitted(self):
             self.emit(
-                ('super({}, self)._process_custom_annotations(annotation_type, context, processor)'
-                 ).format(class_name_for_data_type(data_type))
+                (
+                    'super({}, self)._process_custom_annotations(annotation_type, context, '
+                    'processor)'
+                ).format(class_name_for_data_type(data_type))
             )
             self.emit()
 

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -717,12 +717,12 @@ class PythonTypesBackend(CodeBackend):
         The _process_custom_annotations function allows client code to access
         custom annotations defined in the spec.
         """
-        self.emit('def _process_custom_annotations(self, annotation_type, context, processor):')
+        self.emit('def _process_custom_annotations(self, annotation_type, field_path, processor):')
 
         with self.indent(), emit_pass_if_nothing_emitted(self):
             self.emit(
                 (
-                    'super({}, self)._process_custom_annotations(annotation_type, context, '
+                    'super({}, self)._process_custom_annotations(annotation_type, field_path, '
                     'processor)'
                 ).format(class_name_for_data_type(data_type))
             )
@@ -740,7 +740,7 @@ class PythonTypesBackend(CodeBackend):
                             generate_func_call(
                                 processor,
                                 args=[
-                                    "'{{}}.{}'.format(context)".format(field_name),
+                                    "'{{}}.{}'.format(field_path)".format(field_name),
                                     'self.{}'.format(field_name),
                                 ])
                         ))
@@ -1033,11 +1033,11 @@ class PythonTypesBackend(CodeBackend):
         The _process_custom_annotations function allows client code to access
         custom annotations defined in the spec.
         """
-        self.emit('def _process_custom_annotations(self, annotation_type, context, processor):')
+        self.emit('def _process_custom_annotations(self, annotation_type, field_path, processor):')
         with self.indent(), emit_pass_if_nothing_emitted(self):
             self.emit(
                 (
-                    'super({}, self)._process_custom_annotations(annotation_type, context, '
+                    'super({}, self)._process_custom_annotations(annotation_type, field_path, '
                     'processor)'
                 ).format(class_name_for_data_type(data_type))
             )
@@ -1063,7 +1063,7 @@ class PythonTypesBackend(CodeBackend):
                                 generate_func_call(
                                     processor,
                                     args=[
-                                        "'{{}}.{}'.format(context)".format(field_name),
+                                        "'{{}}.{}'.format(field_path)".format(field_name),
                                         'self._value',
                                     ])
                             ))

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -268,6 +268,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -311,6 +312,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -364,6 +366,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -374,6 +377,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                     Callable,
                     List,
                     Optional,
+                    Text,
                     Type,
                     TypeVar,
                 )""")))
@@ -397,6 +401,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -417,6 +422,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -425,6 +431,7 @@ class TestPythonTypeStubs(unittest.TestCase):
             """).format(headers=_headers.format(textwrap.dedent("""\
                 from typing import (
                     Callable,
+                    Text,
                     Type,
                     TypeVar,
                 )""")))
@@ -441,6 +448,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -449,6 +457,7 @@ class TestPythonTypeStubs(unittest.TestCase):
             """).format(headers=_headers.format(textwrap.dedent("""\
                 from typing import (
                     Callable,
+                    Text,
                     Type,
                     TypeVar,
                 )""")))
@@ -503,6 +512,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
+                    context: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -515,6 +525,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 from typing import (
                     Callable,
                     Optional,
+                    Text,
                     Type,
                     TypeVar,
                 )""")))

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -268,7 +268,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -312,7 +312,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -366,7 +366,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -401,7 +401,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -422,7 +422,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -448,7 +448,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
@@ -512,7 +512,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                 def _process_custom_annotations(
                     self,
                     annotation_type: Type[T],
-                    context: Text,
+                    field_path: Text,
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -198,11 +198,11 @@ class TestGeneratedPythonTypes(unittest.TestCase):
                     self._unannotated_field_value = None
                     self._unannotated_field_present = False
 
-                def _process_custom_annotations(self, annotation_type, processor):
-                    super(MyStruct, self)._process_custom_annotations(annotation_type, processor)
+                def _process_custom_annotations(self, annotation_type, context, processor):
+                    super(MyStruct, self)._process_custom_annotations(annotation_type, context, processor)
 
                     if annotation_type is MyAnnotationType:
-                        self.annotated_field = bb.partially_apply(processor, MyAnnotationType(test_param=42))(self.annotated_field)
+                        self.annotated_field = bb.partially_apply(processor, MyAnnotationType(test_param=42))('{}.annotated_field'.format(context), self.annotated_field)
 
                 def __repr__(self):
                     return 'MyStruct(annotated_field={!r}, unannotated_field={!r})'.format(

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -198,11 +198,11 @@ class TestGeneratedPythonTypes(unittest.TestCase):
                     self._unannotated_field_value = None
                     self._unannotated_field_present = False
 
-                def _process_custom_annotations(self, annotation_type, context, processor):
-                    super(MyStruct, self)._process_custom_annotations(annotation_type, context, processor)
+                def _process_custom_annotations(self, annotation_type, field_path, processor):
+                    super(MyStruct, self)._process_custom_annotations(annotation_type, field_path, processor)
 
                     if annotation_type is MyAnnotationType:
-                        self.annotated_field = bb.partially_apply(processor, MyAnnotationType(test_param=42))('{}.annotated_field'.format(context), self.annotated_field)
+                        self.annotated_field = bb.partially_apply(processor, MyAnnotationType(test_param=42))('{}.annotated_field'.format(field_path), self.annotated_field)
 
                 def __repr__(self):
                     return 'MyStruct(annotated_field={!r}, unannotated_field={!r})'.format(


### PR DESCRIPTION
This diff adds a `field_path` as the second argument to the custom
annotations processor. Custom processors can use this string to
provide helpful error messages that identify the field in which an
error occurs.