### PR TITLE
Use six to set Validator metaclass to ABCMeta

### DIFF
--- a/stone/backends/python_rsrc/stone_validators.py
+++ b/stone/backends/python_rsrc/stone_validators.py
@@ -92,9 +92,8 @@ def generic_type_name(v):
         return type(v).__name__
 
 
-class Validator(object):
+class Validator(six.with_metaclass(ABCMeta, object)):
     """All primitive and composite data types should be a subclass of this."""
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def validate(self, val):


### PR DESCRIPTION
This file uses six so clearly it's meant to work with Python 3, but
the way it was written it wouldn't set the metaclass in that case.