### PR TITLE
Check if data_type is map and format as key value pair

### DIFF
--- a/stone/backends/tsd_helpers.py
+++ b/stone/backends/tsd_helpers.py
@@ -18,6 +18,7 @@ from stone.ir import (
     is_alias,
     is_list_type,
     is_struct_type,
+    is_map_type,
     is_user_defined_type,
 )
 from stone.backends.helpers import (
@@ -63,6 +64,10 @@ def fmt_type_name(data_type, inside_namespace=None):
         fmted_type = _base_type_table.get(data_type.__class__, 'Object')
         if is_list_type(data_type):
             fmted_type += '<' + fmt_type(data_type.data_type, inside_namespace) + '>'
+        elif is_map_type(data_type):
+            key_data_type = _base_type_table.get(data_type.key_data_type, 'string')
+            value_data_type = fmt_type_name(data_type.value_data_type, inside_namespace)
+            fmted_type = '{[key: %s]: %s}' % (key_data_type, value_data_type)
         return fmted_type
 
 def fmt_polymorphic_type_reference(data_type, inside_namespace=None):

--- a/test/test_tsd_types.py
+++ b/test/test_tsd_types.py
@@ -219,6 +219,7 @@ namespace ns2
 struct BaseS
     "This is a test."
     z Int64
+    maptype Map(String, Int64)
 union_closed BaseU
     z
     x String
@@ -231,6 +232,7 @@ alias AliasedBaseU = BaseU
    */
   export interface BaseS {
     z: number;
+    maptype: {[key: string]: number};
   }
 
   export interface BaseUZ {
@@ -260,6 +262,7 @@ struct A1 extends A
     b Boolean
 struct A2 extends A
     c Boolean
+    mapfield Map(String, A)
 union M
     e Boolean
     f String
@@ -303,6 +306,7 @@ union B
 
   export interface A2 extends A {
     c: boolean;
+    mapfield: {[key: string]: A};
   }
 
   /**


### PR DESCRIPTION
`Map(String, T)` types will be converted to a typescript key value pair like `{[key: string]: T}`, instead of plain `Object`.