### PR TITLE
Fix raising ValidationError for bad base64 on Python 3.

### DIFF
--- a/stone/backends/python_rsrc/stone_serializers.py
+++ b/stone/backends/python_rsrc/stone_serializers.py
@@ -13,6 +13,7 @@ than being added to a project.
 from __future__ import absolute_import, unicode_literals
 
 import base64
+import binascii
 import collections
 import datetime
 import functools
@@ -891,7 +892,7 @@ class PythonPrimitiveToStoneDecoder(object):
             else:
                 try:
                     ret = base64.b64decode(val)
-                except TypeError:
+                except (TypeError, binascii.Error):
                     raise bv.ValidationError('invalid base64-encoded bytes')
         elif isinstance(data_type, bv.Void):
             if self.strict and val is not None:

--- a/test/test_python_gen.py
+++ b/test/test_python_gen.py
@@ -418,6 +418,7 @@ class TestDropInModules(unittest.TestCase):
         self.assertEqual(json_decode(bv.Bytes(),
                                      json.dumps(base64.b64encode(b).decode('ascii'))),
                          b)
+        self.assertRaises(bv.ValidationError, json_decode, bv.Bytes(), json.dumps('=non-base64='))
         self.assertRaises(bv.ValidationError,
                           lambda: json_decode(bv.Bytes(), json.dumps(1)))
         self.assertEqual(json_decode(bv.Nullable(bv.String()), json.dumps(None)), None)


### PR DESCRIPTION
base64 on Python 3 likes to propagate binascii errors up.