### PR TITLE
Only allow nullable types to be Optional in .pyi init args

### DIFF
--- a/stone/backends/python_type_stubs.py
+++ b/stone/backends/python_type_stubs.py
@@ -334,10 +334,6 @@ class PythonTypeStubsBackend(CodeBackend):
             field_name_reserved_check = fmt_var(field.name, True)
             field_type = self.map_stone_type_to_pep484_type(ns, field.data_type)
 
-            if not is_nullable_type(field.data_type):
-                self.import_tracker._register_typing_import('Optional')
-                field_type = 'Optional[{}]'.format(field_type)
-
             args.append("{field_name}: {field_type} = ...".format(
                 field_name=field_name_reserved_check,
                 field_type=field_type))

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -254,7 +254,7 @@ class TestPythonTypeStubs(unittest.TestCase):
 
             class Struct1(bb.Struct):
                 def __init__(self,
-                             f1: Optional[bool] = ...) -> None: ...
+                             f1: bool = ...) -> None: ...
 
                 @property
                 def f1(self) -> bool: ...
@@ -276,9 +276,9 @@ class TestPythonTypeStubs(unittest.TestCase):
 
             class Struct2(bb.Struct):
                 def __init__(self,
-                             f2: Optional[List[int]] = ...,
-                             f3: Optional[datetime.datetime] = ...,
-                             f4: Optional[Dict[Text, int]] = ...) -> None: ...
+                             f2: List[int] = ...,
+                             f3: datetime.datetime = ...,
+                             f4: Dict[Text, int] = ...) -> None: ...
 
                 @property
                 def f2(self) -> List[int]: ...
@@ -323,7 +323,6 @@ class TestPythonTypeStubs(unittest.TestCase):
                     Callable,
                     Dict,
                     List,
-                    Optional,
                     Text,
                     Type,
                     TypeVar,
@@ -341,7 +340,7 @@ class TestPythonTypeStubs(unittest.TestCase):
 
             class NestedTypes(bb.Struct):
                 def __init__(self,
-                             list_of_nullables: Optional[List[Optional[int]]] = ...,
+                             list_of_nullables: List[Optional[int]] = ...,
                              nullable_list: Optional[List[int]] = ...) -> None: ...
 
                 @property
@@ -498,7 +497,7 @@ class TestPythonTypeStubs(unittest.TestCase):
 
             class Struct1(bb.Struct):
                 def __init__(self,
-                             f1: Optional[bool] = ...) -> None: ...
+                             f1: bool = ...) -> None: ...
 
                 @property
                 def f1(self) -> bool: ...
@@ -524,7 +523,6 @@ class TestPythonTypeStubs(unittest.TestCase):
             """).format(headers=_headers.format(textwrap.dedent("""\
                 from typing import (
                     Callable,
-                    Optional,
                     Text,
                     Type,
                     TypeVar,

--- a/test/test_python_type_stubs.py
+++ b/test/test_python_type_stubs.py
@@ -214,7 +214,7 @@ def _make_namespace_with_nullable_fields():
     # type: (...) -> ApiNamespace
     ns = ApiNamespace('ns_w_nullable__fields')
 
-    struct = Struct(name='StructWithNullableFields', namespace=ns, ast_node=None)
+    struct = Struct(name='StructWithNullableField', namespace=ns, ast_node=None)
     struct.set_attributes(
         doc=None,
         fields=[
@@ -557,14 +557,17 @@ class TestPythonTypeStubs(unittest.TestCase):
                 )""")))
         self.assertEqual(result, expected)
 
-    def test__generate_base_namespace_module__with_nullable_and_void_fields(self):
+    def test__generate_base_namespace_module__with_nullable_field(self):
         # type: () -> None
+        """
+        Make sure that only Nullable fields are Optional in mypy
+        """
         ns = _make_namespace_with_nullable_fields()
         result = self._evaluate_namespace(ns)
         expected = textwrap.dedent("""\
             {headers}
 
-            class StructWithNullableFields(bb.Struct):
+            class StructWithNullableField(bb.Struct):
                 def __init__(self,
                              non_nullable_field: int = ...,
                              nullable_field: Optional[int] = ...) -> None: ...
@@ -595,7 +598,7 @@ class TestPythonTypeStubs(unittest.TestCase):
                     processor: Callable[[T, U], U],
                 ) -> None: ...
 
-            StructWithNullableFields_validator: bv.Validator = ...
+            StructWithNullableField_validator: bv.Validator = ...
 
             """).format(headers=_headers.format(textwrap.dedent("""\
                 from typing import (


### PR DESCRIPTION
This reverses some of the changes in #126, and is the followup of #131 