### PR TITLE
Fix zipp issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ python =
 commands =
     python setup.py test {posargs}
 deps =
-    zipp < 2.0.0 ; python_version <= 2.7
+    zipp < 2.0.0 ; python_version <= "2.7"
 
 [testenv:check]
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,8 @@ python =
 
 commands =
     python setup.py test {posargs}
-
+deps =
+    zipp < 2.0.0 ; python_version <= 2.7
 
 [testenv:check]
 


### PR DESCRIPTION
Zipp 2.0.0 has dropped support for Python 2.7 (https://github.com/jaraco/zipp/commit/479ac2149d872757160732bc977977ee0192ac51). This causes stone tests in `py27` and `pypy` to fail https://travis-ci.org/dropbox/stone/builds/640228291?utm_medium=notification&utm_source=github_status. Solution is to limit Zipp version on Python 2.7