### PR TITLE
Ensure equality checks work for Stone structs and unions

### DIFF
--- a/stone/backends/python_rsrc/stone_base.py
+++ b/stone/backends/python_rsrc/stone_base.py
@@ -31,6 +31,30 @@ if _MYPY:
 
 class Struct(object):
     # This is a base class for all classes representing Stone structs.
+
+    _all_field_names_ = set()  # type: typing.Set[str]
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        if not isinstance(other, Struct):
+            return False
+
+        if self._all_field_names_ != other._all_field_names_:
+            return False
+
+        if not isinstance(other, self.__class__) and not isinstance(self, other.__class__):
+            return False
+
+        for field_name in self._all_field_names_:
+            if getattr(self, field_name) != getattr(other, field_name):
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        # type: (object) -> bool
+        return not self == other
+
     def _process_custom_annotations(self, annotation_type, field_path, processor):
         # type: (typing.Type[T], typing.Text, typing.Callable[[T, U], U]) -> None
         pass
@@ -39,7 +63,7 @@ class Union(object):
     # TODO(kelkabany): Possible optimization is to remove _value if a
     # union is composed of only symbols.
     __slots__ = ['_tag', '_value']
-    _tagmap = {}  # type: typing.Dict[typing.Text, bv.Validator]
+    _tagmap = {}  # type: typing.Dict[str, bv.Validator]
     _permissioned_tagmaps = set()  # type: typing.Set[typing.Text]
 
     def __init__(self, tag, value=None):

--- a/stone/backends/python_rsrc/stone_serializers.py
+++ b/stone/backends/python_rsrc/stone_serializers.py
@@ -658,12 +658,11 @@ class PythonPrimitiveToStoneDecoder(object):
             else:
                 raise bv.ValidationError("unknown tag '%s'" % tag)
         elif isinstance(obj, dict):
-            tag, val = self.decode_union_dict(
-                data_type, obj)
+            tag, val = self.decode_union_dict(data_type, obj)
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(tag, val)
+        return data_type.definition(six.ensure_str(tag), val)
 
     def decode_union_dict(self, data_type, obj):
         if '.tag' not in obj:
@@ -790,7 +789,7 @@ class PythonPrimitiveToStoneDecoder(object):
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(tag, val)
+        return data_type.definition(six.ensure_str(tag), val)
 
     def decode_struct_tree(self, data_type, obj):
         """


### PR DESCRIPTION
This does two things:
1) Implements a non-hacky equality function for Stone structs
2) Makes the typing of Stone union tags consistent. Currently, in Python 2, code generated union tags are of type `bytes`, but deserialized union tags are of type `unicode`. This causes defining equality through `repr` to not work, since `'u"tag_name"'` will not equal `'"tag_name"'`. Ensuring that the tag is `str` will guarantee the correct behavior. (In Python 2, `str` is `bytes` and in Python 3, `str` is `unicode`).
