### PR TITLE
Add workflow to automatically upload releases to PyPI

### DIFF
--- a/.github/workflows/pypiupload.yaml
+++ b/.github/workflows/pypiupload.yaml
@@ -1,0 +1,40 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish to PyPi
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish to PyPi
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py bdist_wheel
+    - name: Build Sources
+      if: matrix.python-version == '3.x'
+      run: |
+        python setup.py sdist
+    - name: Publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.pypi_secret }}
+      run: |
+        twine check dist/*
+        twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -122,9 +122,9 @@ exception to this rule is afforded for error responses.
 Installation
 ============
 
-Download or clone Stone, and run the following in its root directory::
+Install stone using ``pip``::
 
-    $ sudo python setup.py install
+    $ pip install --user stone
 
 This will install a script ``stone`` to your PATH that can be run from the
 command line::

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as f:
 
 dist = setup(
     name='stone',
-    version='0.0.0',
+    version='1.0.0',
     install_requires=install_reqs,
     setup_requires=setup_requires,
     tests_require=test_reqs,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as f:
 
 dist = setup(
     name='stone',
-    version='0.1',
+    version='1.0.0',
     install_requires=install_reqs,
     setup_requires=setup_requires,
     tests_require=test_reqs,
@@ -58,6 +58,7 @@ dist = setup(
     description='Stone is an interface description language (IDL) for APIs.',
     license='MIT License',
     long_description=README,
+    long_description_content_type='text/x-rst',
     maintainer_email='api-platform@dropbox.com',
     maintainer='Dropbox',
     url='https://github.com/dropbox/stone',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as f:
 
 dist = setup(
     name='stone',
-    version='1.0.0',
+    version='0.0.0',
     install_requires=install_reqs,
     setup_requires=setup_requires,
     tests_require=test_reqs,


### PR DESCRIPTION
We haven't been using semver for this package in the past, but we should if we're going to upload new versions to PyPI regularly. I've decided to bump to 1.0.0 and start from there.

I've manually tested `setup.py {bdist_wheel,sdist}` and `twice check`, looks good.