### PR TITLE
Add py.typed file to make type info available to checkers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ dist = setup(
         'stone.frontend',
         'stone.ir',
     ],
+    package_data={
+        'stone': ['py.typed'],
+    },
     zip_safe=False,
     author_email='kelkabany@dropbox.com',
     author='Ken Elkabany',


### PR DESCRIPTION
Adding this file allows type checkers to use stone's type info when it is included as a dependency. This is especially useful for type checking a stone backend. See [PEP561](https://www.python.org/dev/peps/pep-0561/).