### PR TITLE
Make generated python types import unicode_literals

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as f:
 
 dist = setup(
     name='stone',
-    version='2.2.0',
+    version='2.2.1',
     install_requires=install_reqs,
     setup_requires=setup_requires,
     tests_require=test_reqs,

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -124,6 +124,8 @@ class PythonTypesBackend(CodeBackend):
             self.emit('"""')
             self.emit()
 
+        self.emit("from __future__ import unicode_literals")
+
         self.emit_raw(validators_import)
 
         # Generate import statements for all referenced namespaces.


### PR DESCRIPTION
This is necessary for generating Python 2 compatible code from Python 3.