### PR TITLE
Fixed empty string literal in Swift code

### DIFF
--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -10,7 +10,6 @@ from stone.ir import (
 from stone.backends.swift import (
     base,
     fmt_serial_type,
-    stone_warning,
     SwiftBaseBackend,
     undocumented,
 )
@@ -157,7 +156,7 @@ class SwiftBackend(SwiftBaseBackend):
         check_route_name_conflict(namespace)
 
         ns_class = fmt_class(namespace.name)
-        self.emit_raw(stone_warning)
+        self.emit_raw(base)
         self.emit('/// Routes for the {} namespace'.format(namespace.name))
 
         with self.block('open class {}Routes'.format(ns_class)):

--- a/stone/backends/swift_helpers.py
+++ b/stone/backends/swift_helpers.py
@@ -90,6 +90,8 @@ def fmt_obj(o):
         return 'false'
     if o is None:
         return 'nil'
+    if o == u'':
+        return '""'
     return pprint.pformat(o, width=1)
 
 
@@ -144,7 +146,7 @@ def fmt_default_value(namespace, field):
     elif is_numeric_type(field.data_type):
         return '.number({})'.format(field.default)
     elif is_string_type(field.data_type):
-        return '.str({})'.format(field.default)
+        return '.str({})'.format(fmt_obj(field.default))
     elif is_boolean_type(field.data_type):
         if field.default:
             bool_str = '1'


### PR DESCRIPTION
Fixed empty string literal in generated Swift code and included module imports in generated routes files.

