### PR TITLE
Fix doc string in argument only shows nullable without wrapping data …

### DIFF
--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -18,6 +18,8 @@ from stone.backends.python_types import (
 )
 from stone.ir import (
     is_nullable_type,
+    is_list_type,
+    is_map_type,
     is_struct_type,
     is_tag_ref,
     is_union_type,
@@ -533,6 +535,19 @@ class PythonClientBackend(CodeBackend):
         elif is_user_defined_type(data_type):
             return ':class:`{}.{}.{}`'.format(
                 self.args.types_package, namespace.name, fmt_type(data_type))
+        elif is_nullable_type(data_type):
+            return 'Nullable[{}]'.format(
+                self._format_type_in_doc(namespace, data_type.data_type),
+            )
+        elif is_list_type(data_type):
+            return 'List[{}]'.format(
+                self._format_type_in_doc(namespace, data_type.data_type),
+            )
+        elif is_map_type(data_type):
+            return 'Map[{}, {}]'.format(
+                self._format_type_in_doc(namespace, data_type.key_data_type),
+                self._format_type_in_doc(namespace, data_type.value_data_type),
+            )
         else:
             return fmt_type(data_type)
 

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -1,7 +1,16 @@
 import textwrap
 
 from stone.backends.python_client import PythonClientBackend
-from stone.ir import ApiNamespace, ApiRoute, Void, Int32
+from stone.ir import (
+    ApiNamespace,
+    ApiRoute,
+    Int32,
+    List,
+    Map,
+    Nullable,
+    String,
+    Void,
+)
 
 MYPY = False
 if MYPY:
@@ -195,5 +204,18 @@ class TestGeneratedPythonClient(unittest.TestCase):
         self.assertEqual(
             'There is a name conflict between {!r} and {!r}'.format(route1, route2),
             str(cm.exception))
+
+    def test_route_argument_doc_string(self):
+        backend = PythonClientBackend(
+            target_folder_path='output',
+            args=['-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
+        ns = ApiNamespace('files')
+        self.assertEqual(backend._format_type_in_doc(ns, Int32()), 'int')
+        self.assertEqual(backend._format_type_in_doc(ns, Void()), 'None')
+        self.assertEqual(backend._format_type_in_doc(ns, List(String())), 'List[str]')
+        self.assertEqual(backend._format_type_in_doc(ns, Nullable(String())),
+                         'Nullable[str]')
+        self.assertEqual(backend._format_type_in_doc(ns, Map(String(), Int32())),
+                         'Map[str, int]')
 
     # TODO: add more unit tests for client code generation


### PR DESCRIPTION
…type.

<!--
Thank you for your pull request. Please provide a description below.
-->
Fixing "The Dropbox API v2 Python SDK docs don't show the parameter type when the parameter is optional"

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [ ] Do the tests pass
There are irrelevant test failure (all in JS/TS). I assume it was because the base commit is old. I didn't use the latest commit because of the -p issue. 