### PR TITLE
Fix issue tracking recursive references to custom annotations

### DIFF
--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -108,7 +108,6 @@ _cmdline_parser.add_argument(
 
 
 class PythonClientBackend(CodeBackend):
-    # pylint: disable=attribute-defined-outside-init
 
     cmdline_parser = _cmdline_parser
     supported_auth_types = None

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -14,10 +14,9 @@ if _MYPY:
 
 from stone.ir import AnnotationType, ApiNamespace
 from stone.ir import (
-    get_custom_annotations_for_alias,
-    get_custom_annotations_recursive,
     is_alias,
     is_boolean_type,
+    is_composite_type,
     is_bytes_type,
     is_list_type,
     is_map_type,
@@ -642,7 +641,7 @@ class PythonTypesBackend(CodeBackend):
         dt, _, _ = unwrap(data_type)
         if is_struct_type(dt) or is_union_type(dt):
             annotation_types_seen = set()
-            for annotation in get_custom_annotations_recursive(dt):
+            for _, annotation in dt.recursive_custom_annotations:
                 if annotation.annotation_type not in annotation_types_seen:
                     yield (annotation.annotation_type,
                            generate_func_call(
@@ -672,7 +671,10 @@ class PythonTypesBackend(CodeBackend):
 
         # annotations applied directly to this type (through aliases or
         # passed in from the caller)
-        for annotation in itertools.chain(get_custom_annotations_for_alias(data_type),
+        indirect_annotations = dt.recursive_custom_annotations if is_composite_type(dt) else set()
+        all_annotations = data_type.recursive_custom_annotations if is_composite_type(data_type) else set()
+        remaining_annotations = [annotation for _, annotation in all_annotations.difference(indirect_annotations)]
+        for annotation in itertools.chain(remaining_annotations,
                                           extra_annotations):
             yield (annotation.annotation_type,
                    generate_func_call(

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -672,8 +672,10 @@ class PythonTypesBackend(CodeBackend):
         # annotations applied directly to this type (through aliases or
         # passed in from the caller)
         indirect_annotations = dt.recursive_custom_annotations if is_composite_type(dt) else set()
-        all_annotations = data_type.recursive_custom_annotations if is_composite_type(data_type) else set()
-        remaining_annotations = [annotation for _, annotation in all_annotations.difference(indirect_annotations)]
+        all_annotations = (data_type.recursive_custom_annotations
+                           if is_composite_type(data_type) else set())
+        remaining_annotations = [annotation for _, annotation in
+                                 all_annotations.difference(indirect_annotations)]
         for annotation in itertools.chain(remaining_annotations,
                                           extra_annotations):
             yield (annotation.annotation_type,

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -833,11 +833,13 @@ class IRGenerator(object):
                 for field in data_type.fields:
                     annotations.update(recurse(field.data_type))
                     # annotations can be defined directly on fields
-                    annotations.update([(field, annotation) for annotation in field.custom_annotations])
+                    annotations.update([(field, annotation)
+                                        for annotation in field.custom_annotations])
             elif is_alias(data_type):
                 annotations.update(recurse(data_type.data_type))
                 # annotations can be defined directly on aliases
-                annotations.update([(data_type, annotation) for annotation in data_type.custom_annotations])
+                annotations.update([(data_type, annotation)
+                                    for annotation in data_type.custom_annotations])
             elif is_list_type(data_type):
                 annotations.update(recurse(data_type.data_type))
             elif is_map_type(data_type):

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -37,6 +37,7 @@ from ..ir import (
     Int32,
     Int64,
     is_alias,
+    is_composite_type,
     is_field_type,
     is_list_type,
     is_map_type,
@@ -297,6 +298,7 @@ class IRGenerator(object):
         self._populate_field_defaults()
         self._populate_enumerated_subtypes()
         self._populate_route_attributes()
+        self._populate_recursive_custom_annotations()
         self._populate_examples()
         self._validate_doc_refs()
         self._validate_annotations()
@@ -801,6 +803,73 @@ class IRGenerator(object):
 
         data_type.set_attributes(
             data_type._ast_node.doc, api_type_fields, parent_type, catch_all_field)
+
+    def _populate_recursive_custom_annotations(self):
+        """
+        Populates custom annotations applied to fields recursively. This is done in
+        a separate pass because it requires all fields and routes to be defined so that
+        recursive chains can be followed accurately.
+        """
+        data_types_seen = set()
+
+        def recurse(data_type):
+            # primitive types do not have annotations
+            if not is_composite_type(data_type):
+                return set()
+
+            # if we have already analyzed data type, just return result
+            if data_type.recursive_custom_annotations is not None:
+                return data_type.recursive_custom_annotations
+
+            # handle cycles safely (annotations will be found first time at top level)
+            if data_type in data_types_seen:
+                return set()
+            data_types_seen.add(data_type)
+
+            annotations = set()
+
+            # collect data types from subtypes recursively
+            if is_struct_type(data_type) or is_union_type(data_type):
+                for field in data_type.fields:
+                    annotations.update(recurse(field.data_type))
+                    # annotations can be defined directly on fields
+                    annotations.update([(field, annotation) for annotation in field.custom_annotations])
+            elif is_alias(data_type):
+                annotations.update(recurse(data_type.data_type))
+                # annotations can be defined directly on aliases
+                annotations.update([(data_type, annotation) for annotation in data_type.custom_annotations])
+            elif is_list_type(data_type):
+                annotations.update(recurse(data_type.data_type))
+            elif is_map_type(data_type):
+                # only map values support annotations for now
+                annotations.update(recurse(data_type.value_data_type))
+            elif is_nullable_type(data_type):
+                annotations.update(recurse(data_type.data_type))
+
+            data_type.recursive_custom_annotations = annotations
+            return annotations
+
+        for namespace in self.api.namespaces.values():
+            namespace_annotations = set()
+            for data_type in namespace.data_types:
+                namespace_annotations.update(recurse(data_type))
+
+            for alias in namespace.aliases:
+                namespace_annotations.update(recurse(alias))
+
+            for route in namespace.routes:
+                namespace_annotations.update(recurse(route.arg_data_type))
+                namespace_annotations.update(recurse(route.result_data_type))
+                namespace_annotations.update(recurse(route.error_data_type))
+
+            # record annotation types as dependencies of the namespace. this allows for
+            # an optimization when processing custom annotations to ignore annotation
+            # types that are not applied to the data type, rather than recursing into it
+            for _, annotation in namespace_annotations:
+                if annotation.annotation_type.namespace.name != namespace.name:
+                    namespace.add_imported_namespace(
+                        annotation.annotation_type.namespace,
+                        imported_annotation_type=True)
 
     def _populate_field_defaults(self):
         """

--- a/stone/ir/data_types.py
+++ b/stone/ir/data_types.py
@@ -143,6 +143,7 @@ class Composite(DataType):  # pylint: disable=abstract-method
     data types and other composite types.
     """
     def __init__(self):
+        super(Composite, self).__init__()
         # contains custom annotations that apply to any containing data types (recursively)
         # format is (location, CustomAnnotation) to indicate a custom annotation is applied
         # to a location (Field or Alias)
@@ -915,7 +916,6 @@ class Struct(UserDefined):
     """
     Defines a product type: Composed of other primitive and/or struct types.
     """
-    # pylint: disable=attribute-defined-outside-init
 
     composite_type = 'struct'
 
@@ -1373,7 +1373,6 @@ class Struct(UserDefined):
 
 class Union(UserDefined):
     """Defines a tagged union. Fields are variants."""
-    # pylint: disable=attribute-defined-outside-init
 
     composite_type = 'union'
 

--- a/test/test_python_gen.py
+++ b/test/test_python_gen.py
@@ -229,7 +229,6 @@ class TestDropInModules(unittest.TestCase):
         self.assertEqual(json_encode(bv.Nullable(bv.String()), u'abc'), json.dumps('abc'))
 
     def test_json_encoder_union(self):
-        # pylint: disable=attribute-defined-outside-init
         class S(object):
             _all_field_names_ = {'f'}
             _all_fields_ = [('f', bv.String())]
@@ -331,7 +330,6 @@ class TestDropInModules(unittest.TestCase):
         self.assertEqual(json_encode(bv.Union(U), u, old_style=True), json.dumps({'g': m}))
 
     def test_json_encoder_error_messages(self):
-        # pylint: disable=attribute-defined-outside-init
         class S3(object):
             _all_field_names_ = {'j'}
             _all_fields_ = [('j', bv.UInt64(max_value=10))]

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -171,6 +171,7 @@ class TestGeneratedPythonTypes(unittest.TestCase):
             StructField('unannotated_field', Int32(), None, None),
         ])
         struct.fields[0].set_annotations([annotation])
+        struct.recursive_custom_annotations = set([annotation])
 
         result = self._evaluate_struct(ns, struct)
 

--- a/test/test_stone.py
+++ b/test/test_stone.py
@@ -4933,6 +4933,6 @@ class TestStone(unittest.TestCase):
                                 consider_annotation_types=True)]
         self.assertTrue('test' in alias_namespaces)
 
-        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Custom annotations (introduced in https://github.com/dropbox/stone/pull/110/) allow users to define arbitrary annotations that can be used by calling an autogenerated processor for the Python backend. The Python backend code generation recursively searches for and includes custom annotation types for a backend, but the intermediate code generator does not track references recursively. This leads to missing imports in the Python code generation in some cases.

This change moves the recursive search into the intermediate code generator and puts the result in a new data type field for use in code generation by backends.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?