### PR TITLE
Convert obj-c and swift pattern to str

### DIFF
--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -921,7 +921,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                          if data_type.min_length else 'nil'),
                         ('maxLength', '@({})'.format(data_type.max_length)
                          if data_type.max_length else 'nil'),
-                        ('pattern', '@"{}"'.format(pattern)
+                        ('pattern', '@"{}"'.format(six.ensure_str(pattern))
                          if pattern else 'nil'),
                     ]))
 

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -242,7 +242,7 @@ class SwiftTypesBackend(SwiftBaseBackend):
                 self._func_args([
                     ("minLength", data_type.min_length),
                     ("maxLength", data_type.max_length),
-                    ("pattern", '"{}"'.format(pat) if pat else None),
+                    ("pattern", '"{}"'.format(six.ensure_str(pat)) if pat else None),
                 ])
             )
         else:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
The pattern is currently a bytestring, and the app is failing to compile

```
pattern:@"b"^['&A-Za-z0-9._%+-]+@[A-Za-z0-9-][A-Za-z0-9.-]*\\\\.[A-Za-z]{2,15}$"
```

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?