### PR TITLE
Pin pytest-runner to 5.2.0 (for Python 2.7)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ with open('requirements.txt') as f:
     install_reqs += f.read().splitlines()
 
 setup_requires = [
-    'pytest-runner',
+    # Pin pytest-runner to 5.2.0, since 5.3.0 uses `find_namespaces` directive, not supported in
+    # Python 2.7
+    'pytest-runner == 5.2.0',
 ]
 
 # WARNING: This imposes limitations on test/requirements.txt such that the


### PR DESCRIPTION
Need to do this to fix Explorer spec update.

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?