### PR TITLE
Synchronize access to route singletons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
 install_reqs = []
-with open('requirements.txt') as f:
+with open('requirements.txt', encoding='utf-8') as f:
     install_reqs += f.read().splitlines()
 
 setup_requires = [
@@ -31,10 +31,10 @@ setup_requires = [
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
 test_reqs = []
-with open('test/requirements.txt') as f:
+with open('test/requirements.txt', encoding='utf-8') as f:
     test_reqs += f.read().splitlines()
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     README = f.read()
 
 dist = setup(

--- a/stone/backend.py
+++ b/stone/backend.py
@@ -161,7 +161,7 @@ class Backend(object):
         self.logger.info('Generating %s', full_path)
         self.clear_output_buffer()
         yield
-        with open(full_path, mode) as f:
+        with open(full_path, mode) as f:  # pylint: disable=unspecified-encoding
             f.write(self.output_buffer_to_string().encode('utf-8'))
         self.clear_output_buffer()
 

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -133,7 +133,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
 
         if self.args.documentation:
             jazzy_cfg_path = os.path.join('../Format', 'jazzy.json')
-            with open(jazzy_cfg_path) as jazzy_file:
+            with open(jazzy_cfg_path, encoding='utf-8') as jazzy_file:
                 jazzy_cfg = json.load(jazzy_file)
 
             for idx, namespace in enumerate(api.namespaces.values()):

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -787,6 +787,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
             self.emit('result = prime * result + [[self tagName] hash];')
         else:
             self.emit('result = prime * result + [self.{} hash];'.format(fmt_var(field.name)))
+
     def _generate_equality_func(self, data_type):
         is_equal_func_name = 'isEqualTo{}'.format(fmt_camel_upper(data_type.name))
         with self.block_func(func='isEqual',
@@ -1295,6 +1296,21 @@ class ObjCTypesBackend(ObjCBaseBackend):
                     self.emit('static DBRoute *{};'.format(route_name))
                 self.emit()
 
+                self.emit('static NSObject *lockObj = nil;')
+                with self.block_func(
+                        func='initialize',
+                        args=[],
+                        return_type='void',
+                        class_func=True):
+                    self.emit('static dispatch_once_t onceToken;')
+                    with self.block(
+                            'dispatch_once(&onceToken, ^{',
+                            delim=(None, None),
+                            after='});'):
+                        self.emit('lockObj = [[NSObject alloc] init];')
+                    self.emit()
+                self.emit()
+
                 for route in namespace.routes:
                     route_name = fmt_route_var(namespace.name, route)
                     if route.version == 1:
@@ -1342,40 +1358,42 @@ class ObjCTypesBackend(ObjCBaseBackend):
                             args=[],
                             return_type='DBRoute *',
                             class_func=True):
-                        with self.block('if (!{})'.format(route_name)):
-                            with self.block(
-                                    '{} = [[DBRoute alloc] init:'.format(
-                                        route_name),
-                                    delim=(None, None),
-                                    after='];'):
-                                self.emit('@\"{}\"'.format(route_path))
-                                self.emit('namespace_:@\"{}\"'.format(
-                                    namespace.name))
-                                self.emit('deprecated:{}'.format(deprecated))
-                                self.emit('resultType:{}'.format(result_type))
-                                self.emit('errorType:{}'.format(error_type))
+                        with self.block('@synchronized(lockObj)'):
+                            with self.block('if (!{})'.format(route_name)):
+                                with self.block(
+                                        '{} = [[DBRoute alloc] init:'.format(
+                                            route_name),
+                                        delim=(None, None),
+                                        after='];'):
+                                    self.emit('@\"{}\"'.format(route_path))
+                                    self.emit('namespace_:@\"{}\"'.format(
+                                        namespace.name))
+                                    self.emit('deprecated:{}'.format(deprecated))
+                                    self.emit('resultType:{}'.format(result_type))
+                                    self.emit('errorType:{}'.format(error_type))
 
-                                attrs = []
-                                for field in route_schema.fields:
-                                    attr_key = field.name
-                                    attr_val = ("@\"{}\"".format(route.attrs
-                                            .get(attr_key)) if route.attrs
-                                        .get(attr_key)
-                                        else 'nil')
-                                    attrs.append('@\"{}\": {}'.format(
-                                        attr_key, attr_val))
+                                    attrs = []
+                                    for field in route_schema.fields:
+                                        attr_key = field.name
+                                        attr_val = ("@\"{}\"".format(route.attrs
+                                                .get(attr_key)) if route.attrs
+                                            .get(attr_key)
+                                            else 'nil')
+                                        attrs.append('@\"{}\": {}'.format(
+                                            attr_key, attr_val))
 
-                                self.generate_multiline_list(
-                                    attrs,
-                                    delim=('attrs:@{', '}'),
-                                    compact=True)
+                                    self.generate_multiline_list(
+                                        attrs,
+                                        delim=('attrs:@{', '}'),
+                                        compact=True)
 
-                                self.emit('dataStructSerialBlock:{}'.format(
-                                    dataStructSerialBlock))
-                                self.emit('dataStructDeserialBlock:{}'.format(
-                                    dataStructDeserialBlock))
+                                    self.emit('dataStructSerialBlock:{}'.format(
+                                        dataStructSerialBlock))
+                                    self.emit('dataStructDeserialBlock:{}'.format(
+                                        dataStructDeserialBlock))
 
-                        self.emit('return {};'.format(route_name))
+                            self.emit('return {};'.format(route_name))
+                        self.emit()
                     self.emit()
 
     def _generate_route_objects_h(

--- a/stone/backends/python_rsrc/stone_validators.py
+++ b/stone/backends/python_rsrc/stone_validators.py
@@ -70,12 +70,12 @@ class ValidationError(Exception):
 
 
 def type_name_with_module(t):
-    # type: (typing.Type[typing.Any]) -> six.text_type
+    # type: (typing.Type[typing.Any]) -> typing.Any
     return '%s.%s' % (t.__module__, t.__name__)
 
 
 def generic_type_name(v):
-    # type: (typing.Any) -> six.text_type
+    # type: (typing.Any) -> typing.Any
     """Return a descriptive type name that isn't Python specific. For example,
     an int value will return 'integer' rather than 'int'."""
     if isinstance(v, bool):

--- a/stone/backends/swift.py
+++ b/stone/backends/swift.py
@@ -156,8 +156,6 @@ class SwiftBaseBackend(CodeBackend):
         elif tag in ('type', 'val', 'link'):
             return val
         else:
-            import pdb
-            pdb.set_trace()
             return val
 
 def fmt_serial_type(data_type):

--- a/stone/backends/swift_helpers.py
+++ b/stone/backends/swift_helpers.py
@@ -90,7 +90,7 @@ def fmt_obj(o):
         return 'false'
     if o is None:
         return 'nil'
-    if o == u'':
+    if o == '':
         return '""'
     return pprint.pformat(o, width=1)
 

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -133,7 +133,7 @@ class SwiftTypesBackend(SwiftBaseBackend):
                     self.target_folder_path)
 
         jazzy_cfg_path = os.path.join('../Format', 'jazzy.json')
-        with open(jazzy_cfg_path) as jazzy_file:
+        with open(jazzy_cfg_path, encoding='utf-8') as jazzy_file:
             jazzy_cfg = json.load(jazzy_file)
 
         for namespace in api.namespaces.values():

--- a/stone/backends/tsd_client.py
+++ b/stone/backends/tsd_client.py
@@ -115,7 +115,7 @@ class TSDClientBackend(CodeBackend):
 
         with self.output_to_relative_path(self.args.filename):
             if os.path.isfile(template_path):
-                with open(template_path, 'r') as template_file:
+                with open(template_path, 'r', encoding='utf-8') as template_file:
                     template = template_file.read()
             else:
                 raise AssertionError('TypeScript template file does not exist.')

--- a/stone/backends/tsd_types.py
+++ b/stone/backends/tsd_types.py
@@ -182,7 +182,7 @@ class TSDTypesBackend(CodeBackend):
         template_path = os.path.join(self.target_folder_path, self.args.template)
 
         if os.path.isfile(template_path):
-            with open(template_path, 'r') as template_file:
+            with open(template_path, 'r', encoding='utf-8') as template_file:
                 return template_file.read()
         else:
             raise AssertionError('TypeScript template file does not exist.')

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -197,7 +197,7 @@ def main():
                           file=sys.stderr)
                     sys.exit(1)
                 else:
-                    with open(spec_path) as f:
+                    with open(spec_path, encoding='utf-8') as f:
                         specs.append((spec_path, f.read()))
             if read_from_stdin and specs:
                 print("error: Do not specify stdin and specification files "
@@ -240,7 +240,7 @@ def main():
             route_filter = None
 
         if args.route_whitelist_filter:
-            with open(args.route_whitelist_filter) as f:
+            with open(args.route_whitelist_filter, encoding='utf-8') as f:
                 route_whitelist_filter = json.loads(f.read())
         else:
             route_whitelist_filter = None

--- a/stone/frontend/parser.py
+++ b/stone/frontend/parser.py
@@ -842,7 +842,7 @@ class ParserFactory(object):
         try:
             p[0] = {p[1]: p[3]}
         except TypeError:
-            msg = u"%s is an invalid hash key because it cannot be hashed." % repr(p[1])
+            msg = "%s is an invalid hash key because it cannot be hashed." % repr(p[1])
             self.errors.append((msg, p.lineno(2), self.path))
             p[0] = {}
 

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -104,7 +104,7 @@ class ApiNamespace(object):
     def __init__(self, name):
         # type: (typing.Text) -> None
         self.name = name
-        self.doc = None                    # type: typing.Optional[six.text_type]
+        self.doc = None                    # type: typing.Optional[typing.Any]
         self.routes = []                   # type: typing.List[ApiRoute]
         # TODO (peichao): route_by_name is deprecated by routes_by_name and should be removed.
         self.route_by_name = {}            # type: typing.Dict[typing.Text, ApiRoute]
@@ -120,7 +120,7 @@ class ApiNamespace(object):
         self._imported_namespaces = {}     # type: typing.Dict[ApiNamespace, _ImportReason]
 
     def add_doc(self, docstring):
-        # type: (six.text_type) -> None
+        # type: (typing.Any) -> None
         """Adds a docstring for this namespace.
 
         The input docstring is normalized to have no leading whitespace and

--- a/test/test_js_client.py
+++ b/test/test_js_client.py
@@ -18,7 +18,7 @@ class TestGeneratedJSClient(unittest.TestCase):
     def _get_api(self):
         # type () -> Api
         api = Api(version='0.1b1')
-        api.route_schema = Struct(u'Route', 'stone_cfg', None)
+        api.route_schema = Struct('Route', 'stone_cfg', None)
         route1 = ApiRoute('get_metadata', 1, None)
         route1.set_attributes(None, ':route:`get_metadata`', Void(), Void(), Void(), {})
         route2 = ApiRoute('get_metadata', 2, None)

--- a/test/test_python_gen.py
+++ b/test/test_python_gen.py
@@ -112,7 +112,7 @@ class TestDropInModules(unittest.TestCase):
     def test_bytes_validator(self):
         b = bv.Bytes(min_length=1, max_length=10)
         # Not a valid binary type
-        self.assertRaises(bv.ValidationError, lambda: b.validate(u'asdf'))
+        self.assertRaises(bv.ValidationError, lambda: b.validate('asdf'))
         # Too short
         self.assertRaises(bv.ValidationError, lambda: b.validate(b''))
         # Too long
@@ -212,7 +212,7 @@ class TestDropInModules(unittest.TestCase):
     def test_json_encoder(self):
         self.assertEqual(json_encode(bv.Void(), None), json.dumps(None))
         self.assertEqual(json_encode(bv.String(), 'abc'), json.dumps('abc'))
-        self.assertEqual(json_encode(bv.String(), u'\u2650'), json.dumps(u'\u2650'))
+        self.assertEqual(json_encode(bv.String(), '\u2650'), json.dumps('\u2650'))
         self.assertEqual(json_encode(bv.UInt32(), 123), json.dumps(123))
         # Because a bool is a subclass of an int, ensure they aren't mistakenly
         # encoded as a true/false in JSON when an integer is the data type.
@@ -226,7 +226,7 @@ class TestDropInModules(unittest.TestCase):
         self.assertEqual(json_encode(bv.Bytes(), b),
                          json.dumps(base64.b64encode(b).decode('ascii')))
         self.assertEqual(json_encode(bv.Nullable(bv.String()), None), json.dumps(None))
-        self.assertEqual(json_encode(bv.Nullable(bv.String()), u'abc'), json.dumps('abc'))
+        self.assertEqual(json_encode(bv.Nullable(bv.String()), 'abc'), json.dumps('abc'))
 
     def test_json_encoder_union(self):
         class S(object):
@@ -1489,7 +1489,7 @@ class TestGeneratedPython(unittest.TestCase):
         bs2 = msgpack_decode(bv.Bytes(), s)
         self.assertEqual(bs, bs2)
 
-        u = u'\u2650'
+        u = '\u2650'
         s = msgpack_encode(bv.String(), u)
         u2 = msgpack_decode(bv.String(), s)
         self.assertEqual(u, u2)
@@ -3366,7 +3366,7 @@ class TestAnnotationsGeneratedPython(unittest.TestCase):
                 caller_permissions=self.internal_and_alpha_cp, should_redact=True), json_data)
 
     def test_encoding_unicode_with_redaction(self):
-        unicode_val = u"Unicode val'`~$%&\u53c9\u71d2"
+        unicode_val = "Unicode val'`~$%&\u53c9\u71d2"
 
         json_data = {
             '.tag': 't2',

--- a/test/test_stone_internal.py
+++ b/test/test_stone_internal.py
@@ -192,7 +192,7 @@ class TestStoneInternal(unittest.TestCase):
         s.check('1')
 
         # check correct unicode
-        s.check(u'\u2650')
+        s.check('\u2650')
 
         # check bad item
         with self.assertRaises(ValueError) as cm:

--- a/test/test_tsd_client.py
+++ b/test/test_tsd_client.py
@@ -17,7 +17,7 @@ class TestGeneratedTSDClient(unittest.TestCase):
     def _get_api(self):
         # type () -> Api
         api = Api(version='0.1b1')
-        api.route_schema = Struct(u'Route', 'stone_cfg', None)
+        api.route_schema = Struct('Route', 'stone_cfg', None)
         route1 = ApiRoute('get_metadata', 1, None)
         route1.set_attributes(None, ':route:`get_metadata`', Void(), Void(), Void(), {})
         route2 = ApiRoute('get_metadata', 2, None)

--- a/test/test_tsd_types.py
+++ b/test/test_tsd_types.py
@@ -456,7 +456,7 @@ class TestTSDTypesE2E(unittest.TestCase):
             os.makedirs(self.stone_output_directory)
         self.template_file_name = "typescript.template"
         template_file_path = "{}/{}".format(self.stone_output_directory, self.template_file_name)
-        with open(template_file_path, "w") as template_file:
+        with open(template_file_path, "w", encoding='utf-8') as template_file:
             template_file.write("/*TYPES*/")
 
     def tearDown(self):
@@ -464,7 +464,7 @@ class TestTSDTypesE2E(unittest.TestCase):
         shutil.rmtree('output')
 
     def _verify_generated_output(self, filename, expected_namespace_types):
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             generated_types = f.read()
             self.assertEqual(generated_types, expected_namespace_types)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Makes objective-c route singleton access thread safe by synchronizing over a lock object per file. This has been live in our production iOS app for a week without incident. Example output:

```
static NSObject *lockObj = nil;
+ (void)initialize {
  static dispatch_once_t onceToken;
  dispatch_once(&onceToken, ^{
    lockObj = [[NSObject alloc] init];
  });
}

+ (DBRoute *)DBACCOUNTAppleLogin {
  @synchronized(lockObj) {
    if (!DBACCOUNTAppleLogin) {
      DBACCOUNTAppleLogin =
          [[DBRoute alloc] init:@"apple_login"
                           namespace_:@"account"
                           deprecated:@NO
                           resultType:[DBACCOUNTAppleLoginResult class]
                            errorType:[DBACCOUNTAppleLoginError class]
                                attrs:@{
                                  @"auth" : @"app",
                                  @"host" : @"api",
                                  @"style" : @"rpc"
                                }
                dataStructSerialBlock:nil
              dataStructDeserialBlock:nil];
    }
    return DBACCOUNTAppleLogin;
  }
}

+ (DBRoute *)DBACCOUNTAppleSignup {
  @synchronized(lockObj) {
    if (!DBACCOUNTAppleSignup) {
      DBACCOUNTAppleSignup =
          [[DBRoute alloc] init:@"apple_signup"
                           namespace_:@"account"
                           deprecated:@NO
                           resultType:[DBACCOUNTAppleSignupResult class]
                            errorType:[DBACCOUNTAppleSignupError class]
                                attrs:@{
                                  @"auth" : @"app",
                                  @"host" : @"api",
                                  @"style" : @"rpc"
                                }
                dataStructSerialBlock:nil
              dataStructDeserialBlock:nil];
    }
    return DBACCOUNTAppleSignup;
  }
}
... etc.
```



**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?