### PR TITLE
Add sorting of ApiRoute, guaranteeing stable file output.

### DIFF
--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -1704,6 +1704,11 @@ class IRGenerator(object):
             namespace.routes = []
             namespace.route_by_name = {}
             namespace.routes_by_name = {}
+
+            # We need a stable sort in order to keep the resultant output
+            # the same across runs.
+            routes.sort()
+
             for route in routes:
                 namespace.add_route(route)
 

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -416,6 +416,31 @@ class ApiRoute(object):
     def __repr__(self):
         return 'ApiRoute({})'.format(self.name_with_version())
 
+    def _compare(self, lhs, rhs):
+        if not isinstance(lhs, ApiRoute):
+            raise TypeError("Expected ApiRoute for object: {}".format(lhs))
+        if not isinstance(rhs, ApiRoute):
+            raise TypeError("Expected ApiRoute for object: {}".format(rhs))
+        
+        if lhs.name < rhs.name or lhs.version < rhs.version:
+            return -1
+        elif lhs.name > rhs.name or lhs.version > rhs.version:
+            return 1
+        else:
+            return 0
+
+    def __lt__(self, other):
+        return self._compare(self, other) < 0
+    def __gt__(self, other):
+        return self._compare(self, other) > 0
+    def __eq__(self, other):
+        return self._compare(self, other) == 0
+    def __le__(self, other):
+        return self._compare(self, other) <= 0
+    def __ge__(self, other):
+        return self._compare(self, other) >= 0
+    def __ne__(self, other):
+        return self._compare(self, other) != 0
 
 class DeprecationInfo(object):
 

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -421,7 +421,7 @@ class ApiRoute(object):
             raise TypeError("Expected ApiRoute for object: {}".format(lhs))
         if not isinstance(rhs, ApiRoute):
             raise TypeError("Expected ApiRoute for object: {}".format(rhs))
-        
+
         if lhs.name < rhs.name or lhs.version < rhs.version:
             return -1
         elif lhs.name > rhs.name or lhs.version > rhs.version:

--- a/test/test_stone_route_whitelist.py
+++ b/test/test_stone_route_whitelist.py
@@ -85,28 +85,27 @@ class TestStone(unittest.TestCase):
                 "Additional Route"
 
             """)
-        
+
         route_whitelist = ["OtherRoute", "TestRoute"]
 
-        for x in range(2,100):
+        for x in range(2, 100):
             text += textwrap.dedent("""\
             route TestRoute:{} (TestArg, TestResult, Void)
                 "test doc"
             """.format(x))
             route_whitelist.append("TestRoute:{}".format(x))
 
-
         route_whitelist_filter = {
             "route_whitelist": {"test": route_whitelist},
             "datatype_whitelist": {}
         }
-        
+
         api = specs_to_ir([('test.stone', text)], route_whitelist_filter=route_whitelist_filter)
         routes = api.namespaces['test'].routes
         self.assertEqual(len(routes), 100)
         self.assertEqual(routes[0].name, "OtherRoute")
 
-        for x in range(1,100):
+        for x in range(1, 100):
             self.assertEqual(routes[x].name, "TestRoute")
             self.assertEqual(routes[x].version, x)
 


### PR DESCRIPTION
For generations using the JSON-allowlist, the current version does not guarantee that source will be written in the same order. I have addressed this by making sure routes are added in a stable order.

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?