### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/pypiupload.yaml
+++ b/.github/workflows/pypiupload.yaml
@@ -4,8 +4,8 @@
 name: Publish to PyPi
 
 on:
-  release:
-    types: [created]
+  pull_request:
+# DO NOT MERGE THIS CHANGE - for testing
 
 jobs:
   deploy:

--- a/.github/workflows/pypiupload.yaml
+++ b/.github/workflows/pypiupload.yaml
@@ -4,8 +4,8 @@
 name: Publish to PyPi
 
 on:
-  pull_request:
-# DO NOT MERGE THIS CHANGE - for testing
+  release:
+    types: [created]
 
 jobs:
   deploy:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
 install_reqs = []
-with open('requirements.txt') as f:
+with open('requirements.txt') as f:  # pylint: disable=W1514
     install_reqs += f.read().splitlines()
 
 setup_requires = [
@@ -31,10 +31,10 @@ setup_requires = [
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
 test_reqs = []
-with open('test/requirements.txt') as f:
+with open('test/requirements.txt') as f:  # pylint: disable=W1514
     test_reqs += f.read().splitlines()
 
-with open('README.rst') as f:
+with open('README.rst') as f:  # pylint: disable=W1514
     README = f.read()
 
 dist = setup(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
 install_reqs = []
-with open('requirements.txt', encoding='utf-8') as f:
+with open('requirements.txt') as f:
     install_reqs += f.read().splitlines()
 
 setup_requires = [
@@ -31,10 +31,10 @@ setup_requires = [
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
 test_reqs = []
-with open('test/requirements.txt', encoding='utf-8') as f:
+with open('test/requirements.txt') as f:
     test_reqs += f.read().splitlines()
 
-with open('README.rst', encoding='utf-8') as f:
+with open('README.rst') as f:
     README = f.read()
 
 dist = setup(
@@ -67,7 +67,7 @@ dist = setup(
     maintainer='Dropbox',
     url='https://github.com/dropbox/stone',
     classifiers=[
-        'Development Status :: 5 - Stable',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
The latest release didn't successfully publish; this fixes the errors from the GitHub actions.

The failed runs are [here](https://github.com/dropbox/stone/actions/runs/1741665111). For Python 2, `encoding` is not a valid keyword for `open`, so removed that. And for Python 3 PyPi returned a 400 status code saying `Development Status :: 5 - Stable` is an invalid input, so looked up the new string and added that. Also temporarily updated the workflow to run on PR, it successfully ran and published [here](https://github.com/dropbox/stone/runs/4927335102?check_suite_focus=true).