### PR TITLE
Fix python client attribute output to handle None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open('README.rst') as f:  # pylint: disable=W1514
 
 dist = setup(
     name='stone',
-    version='3.3.0',
+    version='3.3.1',
     install_requires=install_reqs,
     setup_requires=setup_requires,
     tests_require=test_reqs,

--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -396,7 +396,7 @@ class PythonClientBackend(CodeBackend):
         attrs_lines = []
         if self.args.attribute_comment and attrs:
             for attribute in self.args.attribute_comment:
-                if attribute in attrs:
+                if attribute in attrs and attrs[attribute] is not None:
                     attrs_lines.append('{}: {}'.format(attribute, attrs[attribute]))
 
         if not fields and not overview and not attrs_lines:

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -253,6 +253,37 @@ class TestGeneratedPythonClient(unittest.TestCase):
         ''')
         self.assertEqual(result, expected)
 
+    def test_route_with_none_attribute_in_docstring(self):
+        # type: () -> None
+
+        route = ApiRoute('get_metadata', 1, None)
+        route.set_attributes(None, None, Void(), Void(), Void(), {
+            'scope': 'events.read', 'another_attribute': None
+        })
+        ns = ApiNamespace('files')
+        ns.add_route(route)
+
+        result = self._evaluate_namespace(ns)
+        expected = textwrap.dedent('''\
+            def files_get_metadata(self):
+                """
+                Route attributes:
+                    scope: events.read
+
+                :rtype: None
+                """
+                arg = None
+                r = self.request(
+                    files.get_metadata,
+                    'files',
+                    arg,
+                    None,
+                )
+                return None
+
+        ''')
+        self.assertEqual(result, expected)
+
     def test_route_with_attributes_and_doc_in_docstring(self):
         # type: () -> None
         """


### PR DESCRIPTION
In testing 3.3.0 with the Python SDK, turns out routes without the attribute defined have values of "None". This PR tweaks the logic from #262 to handle None, and adds a regression test.

Also updates the version to so as a follow I can publish the fix.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?