### PR TITLE
avoid syntax error in .d.ts when the module names end up long

### DIFF
--- a/stone/backends/tsd_types.py
+++ b/stone/backends/tsd_types.py
@@ -249,7 +249,7 @@ class TSDTypesBackend(CodeBackend):
         if namespace.doc:
             self._emit_tsdoc_header(namespace.doc)
 
-        self.emit_wrapped_text(self._get_top_level_declaration(namespace.name))
+        self.emit(self._get_top_level_declaration(namespace.name))
 
         with self.indent(dent=spaces_per_indent):
             for data_type in data_types:


### PR DESCRIPTION
It is not legal typescript to wrap a `declare module "foo/bar" {` statement - this is a SyntaxError.  as such, we need to `self.emit()` this statement instead of `self.emit_wrapped_text()`.

## **Checklist**
**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

Do I need to? I work for Dropbox.

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?