### PR TITLE
Remove use of deprecated mypy option

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
 # follow_imports = False
 ignore_missing_imports = True
-show_none_errors = True
 strict_optional = True


### PR DESCRIPTION
`show_none_errors` is deprecated, see https://github.com/python/mypy/pull/13507