### PR TITLE
Version compatible inspect handling for class parameters

### DIFF
--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import copy
 import logging
 
+from inspect import isclass
 try:
     from inspect import getfullargspec as get_args
 except ImportError:
@@ -1158,7 +1159,7 @@ class IRGenerator(object):
         if obj is Void and type_ref.nullable:
             raise InvalidSpec('Void cannot be marked nullable.',
                               *loc)
-        elif inspect.isclass(obj):
+        elif isclass(obj):
             resolved_data_type_args = self._resolve_args(env, type_ref.args)
             data_type = self._instantiate_data_type(
                 obj, resolved_data_type_args, (type_ref.lineno, type_ref.path))

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -3,8 +3,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import defaultdict
 
 import copy
-import inspect
 import logging
+
+try:
+    from inspect import getfullargspec as get_args
+except ImportError:
+    from inspect import getargspec as get_args
 
 _MYPY = False
 if _MYPY:
@@ -1074,7 +1078,7 @@ class IRGenerator(object):
         assert issubclass(data_type_class, DataType), \
             'Expected stone.data_type.DataType, got %r' % data_type_class
 
-        argspec = inspect.getargspec(data_type_class.__init__)  # noqa: E501 # pylint: disable=deprecated-method,useless-suppression
+        argspec = get_args(data_type_class.__init__)  # noqa: E501 # pylint: disable=deprecated-method,useless-suppression
         argspec.args.remove('self')
         num_args = len(argspec.args)
         # Unfortunately, argspec.defaults is None if there are no defaults


### PR DESCRIPTION
`getargspec` was deprecated in Python 3.0, but finally removed in Python 3.11. For reference: https://github.com/Pylons/pyramid/issues/3688

That seems like a valid amount of time for us to have fixed it.

We can do our best effort and if the user is running a Python version that still has `getargspec` use that, but if they have `getfullargspec` which is available in Python 3.11, we can use that.

## **Checklist**

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?