### PR TITLE
Allow Swift background routes without ObjC counterparts

### DIFF
--- a/stone/backends/swift_rsrc/ObjCRequestBox.jinja
+++ b/stone/backends/swift_rsrc/ObjCRequestBox.jinja
@@ -17,6 +17,8 @@ extension DropboxBaseRequestBox {
             case .{{ fmt_func(route.name, route.version) }}(let swift):
                 return {{ fmt_route_objc_class(namespace, route, args_data) }}(swift: swift)
             {% endfor %}
+            default:
+                fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

There was an accidental incorrect assumption in the previous code that every Swift background-compatible route (upload/download route) would have a ObjC wrapper route. This isn't true, for example there is no need to generate the ObjC wrapper for a route called only in Swift. 

This change allows users to include a route in the Swift allow list without including it in the ObjC one by making the ObjC compatibility switch statement non-exhaustive.