### PR TITLE
Remove git sha in favor of SDK version

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,7 +10,7 @@ jobs:
     # https://github.com/actions/python-versions/blob/main/versions-manifest.json
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-20.04]
+        os: [macos-latest, ubuntu-latest]
         python-version: [3.6, 3.7, 3.8, pypy-3.7]
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip
-          pip install flake8==5.0.4 pylint pytest
+          pip install flake8 pylint pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
           python setup.py install

--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
-import sys
 import jinja2
 import textwrap
-import subprocess
 
 from stone.ir import (
     is_struct_type,

--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -282,20 +282,9 @@ class SwiftBackend(SwiftBaseBackend):
         template.globals['fmt_func'] = fmt_func
         template.globals['fmt_class'] = fmt_class
 
-        cmd = "git rev-parse --short HEAD"
-
-        process = subprocess.Popen(cmd.split(), cwd="..", text=True, stdout=subprocess.PIPE)
-        output, error = process.communicate()
-        git_sha = output[:7]
-
-        if error is not None:
-            print("error: Git sha creation error: '%s'" % error,
-                  file=sys.stderr)
-            sys.exit(1)
-
         output_from_parsed_template = template.render(
-            background_compatible_namespace_route_pairs=background_compatible_pairs,
-            git_sha=git_sha)
+            background_compatible_namespace_route_pairs=background_compatible_pairs
+        )
         self._write_output_in_target_folder(output_from_parsed_template,
                                             'ReconnectionHelpers.swift')
 

--- a/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
+++ b/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
@@ -5,8 +5,6 @@
 import Foundation
 
 enum ReconnectionHelpers {
-    /// Seven character SDK git sha: `git rev-parse --short HEAD`
-    static let GitSha = "{{ git_sha }}"
 
     static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> DropboxBaseRequestBox {
         let info = try persistedRequestInfo(from: apiRequest)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

It's possible that an iOS background session task is created by one version of the SDK and handled by another. We previously used the git sha of the parent dir (the swift SDK) to understand if this case was occurring, but that method is fragile. Instead use the SDK version.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?