### PR TITLE
Fix ci for beta branch

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,7 +10,7 @@ jobs:
     # https://github.com/actions/python-versions/blob/main/versions-manifest.json
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8, pypy-3.7]
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pylint pytest
+          pip install flake8==5.0.4 pylint pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
           python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,8 @@ command line::
 
     $ stone -h
 
+Stone requires Python 3.
+
 Alternative
 -----------
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
 # follow_imports = False
 ignore_missing_imports = True
-show_none_errors = True
 strict_optional = True

--- a/stone/backends/js_types.py
+++ b/stone/backends/js_types.py
@@ -24,7 +24,6 @@ if _MYPY:
 
 import argparse
 
-
 _cmdline_parser = argparse.ArgumentParser(prog='js-types-backend')
 _cmdline_parser.add_argument(
     'filename',

--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -33,7 +33,6 @@ if _MYPY:
 
 import argparse
 
-
 # This will be at the top of the generated file.
 base = """\
 # -*- coding: utf-8 -*-

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -43,7 +43,6 @@ if _MYPY:
 
 import argparse
 
-
 _cmdline_parser = argparse.ArgumentParser(prog='swift-types-backend')
 _cmdline_parser.add_argument(
     '-r',

--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -9,7 +9,7 @@ from inspect import isclass
 try:
     from inspect import getfullargspec as get_args
 except ImportError:
-    from inspect import getargspec as get_args
+    from inspect import getargspec as get_args  # type: ignore
 
 _MYPY = False
 if _MYPY:

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 # See <https://github.com/PyCQA/pylint/issues/73>
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion  # pylint: disable=deprecated-module
 import six
 
 from .data_types import (

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -30,7 +30,6 @@ if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 import argparse
-
 class _Tester(CodeBackend):
     """A no-op backend used to test helper methods."""
     def generate(self, api):

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     pylint --rcfile=.pylintrc setup.py example stone test
 
 deps =
-    flake8
+    flake8<6
     pylint
     # This probably breaks on Windows. See
     # <https://github.com/tox-dev/tox/issues/384>.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Ignores a flake8 type error caused by a conditional import of two (similar for our purposes) types.
Pins flake8 to a version <6 as versions past that no longer parse type annotations. Without the type annotations, we encounter "imported but unused" errors.
Removes now-unrecognized `show_none_errors` mypy setting. Apparently `strict_optional` enforces this anyway.
Pins linux to ubuntu-20.04, as versions past that no longer ship with python 3.6.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [x] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?