### PR TITLE
Replace uses of deprecated imp with importlib

### DIFF
--- a/stone/cli.py
+++ b/stone/cli.py
@@ -168,8 +168,7 @@ def main():
         # The module should should contain an api variable that references a
         # :class:`stone.api.Api` object.
         try:
-            api_module = _load_module('api', args.api[0])
-            api = api_module.api
+            api = _load_module('api', args.api[0]).api
         except ImportError as e:
             print('error: Could not import API description due to:',
                   e, file=sys.stderr)

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -377,7 +377,7 @@ def _load_module(name, path):
         module_specs.loader.exec_module(module)
     else:
         loader = importlib.machinery.SourceFileLoader(module_name, path)
-        module = loader.load_module() # noqa: W4902, E1120
+        module = loader.load_module()  # noqa: W4902, E1120
 
     sys.modules[name] = module
 

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -371,9 +371,13 @@ def _load_module(name, path):
     file_name = os.path.basename(path)
     module_name = file_name.replace('.', '_')
 
-    module_specs = importlib.util.spec_from_file_location(module_name, path)
-    module = importlib.util.module_from_spec(module_specs)
-    module_specs.loader.exec_module(module)
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+        module_specs = importlib.util.spec_from_file_location(module_name, path)
+        module = importlib.util.module_from_spec(module_specs)
+        module_specs.loader.exec_module(module)
+    else:
+        loader = importlib.machinery.SourceFileLoader(module_name, path)
+        module = loader.load_module()
 
     sys.modules[name] = module
 

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -377,7 +377,7 @@ def _load_module(name, path):
         module_specs.loader.exec_module(module)
     else:
         loader = importlib.machinery.SourceFileLoader(module_name, path)
-        module = loader.load_module()  # noqa: W4902,E1120
+        module = loader.load_module()  # pylint: disable=deprecated-method,no-value-for-parameter
 
     sys.modules[name] = module
 

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -377,7 +377,7 @@ def _load_module(name, path):
         module_specs.loader.exec_module(module)
     else:
         loader = importlib.machinery.SourceFileLoader(module_name, path)
-        module = loader.load_module()
+        module = loader.load_module() # noqa: W4902, E1120
 
     sys.modules[name] = module
 

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -377,7 +377,7 @@ def _load_module(name, path):
         module_specs.loader.exec_module(module)
     else:
         loader = importlib.machinery.SourceFileLoader(module_name, path)
-        module = loader.load_module()  # noqa: W4902, E1120
+        module = loader.load_module()  # noqa: W4902,E1120
 
     sys.modules[name] = module
 

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -139,7 +139,6 @@ _filter_ns_group.add_argument(
 
 def main():
     """The entry point for the program."""
-
     if '--' in sys.argv:
         cli_args = sys.argv[1:sys.argv.index('--')]
         backend_args = sys.argv[sys.argv.index('--') + 1:]
@@ -168,7 +167,8 @@ def main():
         # The module should should contain an api variable that references a
         # :class:`stone.api.Api` object.
         try:
-            api = _load_module('api', args.api[0]).api
+            api_module = _load_module('api', args.api[0])
+            api = api_module.api  # pylint: disable=redefined-outer-name
         except ImportError as e:
             print('error: Could not import API description due to:',
                   e, file=sys.stderr)

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -5,7 +5,7 @@ A command-line interface for StoneAPI.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import codecs
-import imp  # pylint: disable=deprecated-module
+import importlib
 import io
 import json
 import logging
@@ -137,7 +137,6 @@ _filter_ns_group.add_argument(
     help='If set, backends will not see any routes for the specified namespaces.',
 )
 
-
 def main():
     """The entry point for the program."""
 
@@ -169,7 +168,8 @@ def main():
         # The module should should contain an api variable that references a
         # :class:`stone.api.Api` object.
         try:
-            api = imp.load_source('api', args.api[0]).api  # pylint: disable=redefined-outer-name
+            api_module = _load_module('api', args.api[0])
+            api = api_module.api
         except ImportError as e:
             print('error: Could not import API description due to:',
                   e, file=sys.stderr)
@@ -342,7 +342,7 @@ def main():
         if new_python_path not in sys.path:
             sys.path.append(new_python_path)
         try:
-            backend_module = imp.load_source('user_backend', args.backend)
+            backend_module = _load_module('user_backend', args.backend)
         except Exception:
             print("error: Importing backend '%s' module raised an exception:" %
                   args.backend, file=sys.stderr)
@@ -368,6 +368,17 @@ def main():
         # easier to do debugging.
         return api
 
+def _load_module(name, path):
+    file_name = os.path.basename(path)
+    module_name = file_name.replace('.', '_')
+
+    module_specs = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(module_specs)
+    module_specs.loader.exec_module(module)
+
+    sys.modules[name] = module
+
+    return module
 
 if __name__ == '__main__':
     # Assign api variable for easy debugging from a Python console

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 # See <https://github.com/PyCQA/pylint/issues/73>
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion  # pylint: disable=deprecated-module
 import six
 
 from .data_types import (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Imp is removed in Python3.12, we should use importlib instead. This will also quiet some deprecation warnings.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?