### PR TITLE
Generate missing app auth routes, clean up task reconnection helpers

### DIFF
--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -212,7 +212,8 @@ class SwiftBackend(SwiftBaseBackend):
         template_globals['objc_init_args_to_swift'] = self._objc_init_args_to_swift
         template_globals['objc_result_from_swift'] = self._objc_result_from_swift
         template_globals['objc_no_defualts_func_args'] = self._objc_no_defualts_func_args
-        template_globals['objc_app_auth_route_wrapper_already_defined'] = self._objc_app_auth_route_wrapper_already_defined
+        template_globals['objc_app_auth_route_wrapper_already_defined'] = \
+            self._objc_app_auth_route_wrapper_already_defined
 
         ns_class = self._class_name(fmt_class(namespace.name))
 
@@ -254,14 +255,16 @@ class SwiftBackend(SwiftBaseBackend):
             template.globals = template_globals
 
             # don't include the default case in the generated switch statement if it's unreachable
-            include_default_in_switch = len(background_objc_routes) < len(background_compatible_routes)
+            include_default_in_switch = \
+                len(background_objc_routes) < len(background_compatible_routes)
 
-            class_name = 'DBX{}RequestBox'.format(self.args.class_name)
-            output = template.render(background_compatible_routes=background_compatible_routes,
-                                    background_objc_routes=background_objc_routes,
-                                    class_name=swift_class_name,
-                                    include_default_in_switch=include_default_in_switch
-                                    )
+            output = template.render(
+                background_compatible_routes=background_compatible_routes,
+                background_objc_routes=background_objc_routes,
+                class_name=swift_class_name,
+                include_default_in_switch=include_default_in_switch
+            )
+
             file_name = 'DBX{}RequestBox.swift'.format(self.args.class_name)
             self._write_output_in_target_folder(output,
                                                 file_name,
@@ -298,7 +301,9 @@ class SwiftBackend(SwiftBaseBackend):
             background_compatible_namespace_route_pairs=background_compatible_pairs
         )
 
-        self._write_output_in_target_folder(output_from_parsed_template, '{}.swift'.format(class_name))
+        self._write_output_in_target_folder(
+            output_from_parsed_template, '{}.swift'.format(class_name)
+        )
 
     def _background_compatible_routes(self, api):
         background_compatible_pairs = self._background_compatible_namespace_route_pairs(api)
@@ -342,13 +347,14 @@ class SwiftBackend(SwiftBaseBackend):
         client_auth_type = self.args.auth_type
 
         # if building the app client, only include app auth routes
-        # if building the user or team client, include routes of all auth types except app auth exclusive routes
+        # if building the user or team client, include routes of all auth types except
+        # app auth exclusive routes
 
         is_app_auth_only_route = route_auth_type == 'app'
         route_auth_types_include_app = 'app' in route_auth_type
 
         if client_auth_type == 'app':
-            return is_app_auth_only_route  or route_auth_types_include_app
+            return is_app_auth_only_route or route_auth_types_include_app
         else:
             return not is_app_auth_only_route
 
@@ -565,7 +571,8 @@ class SwiftBackend(SwiftBaseBackend):
         objc_class_to_route = {}
         for namespace in namespaces:
             for route in namespace.routes:
-                if self._background_session_route_style(route) is not None and self._valid_route_for_auth_type(route):
+                bg_route_style = self._background_session_route_style(route)
+                if bg_route_style is not None and self._valid_route_for_auth_type(route):
                     args_data = self._route_client_args(route)[0]
                     objc_class = self._fmt_route_objc_class(namespace, route, args_data)
                     objc_class_to_route[objc_class] = [namespace, route, args_data]

--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -358,6 +358,10 @@ class SwiftBackend(SwiftBaseBackend):
         else:
             return not is_app_auth_only_route
 
+    # The objc compatibility wrapper generates a class to wrap each route providing properly
+    # typed completion handlers without generics. User and App clients are generated in separate
+    # passes, and if the wrapper is already defined for the user client, we must skip generating
+    # a second definition of it for the app client.
     def _objc_app_auth_route_wrapper_already_defined(self, route):
         client_auth_type = self.args.auth_type
         is_app_auth_client = client_auth_type == 'app'

--- a/stone/backends/swift_rsrc/ObjCRequestBox.jinja
+++ b/stone/backends/swift_rsrc/ObjCRequestBox.jinja
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftyDropbox
 
-extension DropboxBaseRequestBox {
+extension {{ class_name }} {
     var objc: DBXRequest {
         switch self {
             {% for route_args_data in background_objc_routes %}
@@ -17,8 +17,10 @@ extension DropboxBaseRequestBox {
             case .{{ fmt_func(route.name, route.version) }}(let swift):
                 return {{ fmt_route_objc_class(namespace, route, args_data) }}(swift: swift)
             {% endfor %}
+            {% if include_default_in_switch %}
             default:
                 fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
+            {% endif %}
         }
     }
 }

--- a/stone/backends/swift_rsrc/ObjCRoutes.jinja
+++ b/stone/backends/swift_rsrc/ObjCRoutes.jinja
@@ -80,6 +80,9 @@ public class DBX{{ namespace_name }}Routes: NSObject {
 {% for route_args_data in routes_for_objc_requests(namespace) %}
 {% set route = route_args_data[0] %}
 {% if valid_route_for_auth_type(route) is true %}
+
+{# do not redefine DBXRequests defined by the user auth client #}
+{% if not objc_app_auth_route_wrapper_already_defined(route) %}
 {% set args_data = route_args_data[1] %}
 {% set request_object_name = request_object_name(route, args_data) %}
 {% set result_serial_type = fmt_serial_type(route.result_data_type) %}
@@ -179,5 +182,6 @@ public class {{ fmt_route_objc_class(namespace, route, args_data) }}: NSObject, 
     }
 }
 
+{% endif %}
 {% endif %}
 {% endfor %}

--- a/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
+++ b/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
@@ -4,9 +4,9 @@
 
 import Foundation
 
-enum ReconnectionHelpers {
+enum {{ class_name }} {
 
-    static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> DropboxBaseRequestBox {
+    static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> {{ return_type }} {
         let info = try persistedRequestInfo(from: apiRequest)
 
         switch info.routeName {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

In the stone intermediate representation of the api, route auth types can either be a string or an array of strings. Previously, stone only identified a route as app-auth if it was exclusively app auth, it never checked to see if the array contained the app auth type. This led to some app auth routes not being included in the app auth clients.

This PR correctly identifies these multi-auth routes as app auth. It also ensures that we don't create duplicate objc compatibility wrappers for routes that are both app auth and some other auth.

It also makes a pair of small changes to background session task reconnection helpers: App auth routes now get their own reconnection helpers, and objc wrappers over reconnection helpers are slightly modified to avoid potentially creating unreachable defaults in switch statements.

See https://github.com/dropbox/SwiftyDropbox/pull/396 for the modified output code.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [x] Do the tests pass?