### PR TITLE
Make documentation generation optional and improve objc path specification

### DIFF
--- a/stone/backends/swift.py
+++ b/stone/backends/swift.py
@@ -269,14 +269,8 @@ class SwiftBaseBackend(CodeBackend):
         else:
             return val
 
-    def _write_output_in_target_folder(self, output, file_name, objc=False, rop=None):
+    def _write_output_in_target_folder(self, output, file_name):
         full_path = self.target_folder_path
-        if objc:
-            if rop is None:
-                full_path = full_path.replace('Source/SwiftyDropbox', 'Source/SwiftyDropboxObjC')
-            else:
-                full_path = '{}{}'.format(full_path, rop)
-
         if not os.path.exists(full_path):
             os.mkdir(full_path)
         full_path = os.path.join(full_path, file_name)

--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -87,15 +87,9 @@ _cmdline_parser.add_argument(
     help='The dict that maps a style type to a Swift request object name.',
 )
 _cmdline_parser.add_argument(
-    '-objc',
+    '--objc',
     action='store_true',
-    help='Generate the Objective-C compatibile files as well as the standard Swift files.',
-)
-_cmdline_parser.add_argument(
-    '-rop',
-    '--relative-objc-path',
-    type=str,
-    help='Custom output path for Objective-C compatible files relative to the standard Swift files',
+    help='Generate the Objective-C compatibile files.',
 )
 
 
@@ -146,7 +140,8 @@ class SwiftBackend(SwiftBaseBackend):
 
         self._generate_client(api)
         self._generate_request_boxes(api)
-        self._generate_reconnection_helpers(api)
+        if not self.args.objc:
+            self._generate_reconnection_helpers(api)
 
     def _generate_client(self, api):
         template_globals = {}
@@ -160,9 +155,7 @@ class SwiftBackend(SwiftBaseBackend):
             template.globals = template_globals
 
             self._write_output_in_target_folder(template.render(),
-                                                'DBX{}.swift'.format(self.args.module_name),
-                                                True,
-                                                self.args.relative_objc_path)
+                                                'DBX{}.swift'.format(self.args.module_name))
         else:
             template = self._jinja_template("SwiftClient.jinja")
             template.globals = template_globals
@@ -224,9 +217,7 @@ class SwiftBackend(SwiftBaseBackend):
             output_from_parsed_template = template.render(namespace=namespace)
 
             self._write_output_in_target_folder(output_from_parsed_template,
-                                                'DBX{}Routes.swift'.format(ns_class),
-                                                True,
-                                                self.args.relative_objc_path)
+                                                'DBX{}Routes.swift'.format(ns_class))
         else:
             template = self._jinja_template("SwiftRoutes.jinja")
             template.globals = template_globals
@@ -267,9 +258,7 @@ class SwiftBackend(SwiftBaseBackend):
 
             file_name = 'DBX{}RequestBox.swift'.format(self.args.class_name)
             self._write_output_in_target_folder(output,
-                                                file_name,
-                                                True,
-                                                self.args.relative_objc_path)
+                                                file_name)
         else:
             template = self._jinja_template("SwiftRequestBox.jinja")
             template.globals = template_globals

--- a/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
+++ b/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum {{ class_name }} {
+enum {{ class_name }}: ReconnectionHelpersShared {
 
     static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> {{ return_type }} {
         let info = try persistedRequestInfo(from: apiRequest)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

These changes allow generate_base_client.py to be run from directories other than where it is located, the root of SwiftyDropbox.

Paired with: https://github.com/dropbox/SwiftyDropbox/pull/401

- Documentation generation is now optional
- `-rop` flag is removed
- Comment on `--objc` option updated updated to not suggest that a single pass generation is possible.
- `_write_output_in_target_folder` simplified to just write to `self.target_folder_path` + `file name`. For objc generation specify the output location using `-o`.
- Reconnection helper code gen made a little bit more flexible by changing the protocol conformance from a handwritten file to the generated one.


## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?