### PR TITLE
Fix objc wrapper request box default inclusion

### DIFF
--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -247,7 +247,8 @@ class SwiftBackend(SwiftBaseBackend):
             template.globals = template_globals
 
             # don't include the default case in the generated switch statement if it's unreachable
-            include_default_in_switch = True # TODO(jlocke): implement this to eliminate the unreachable code warning
+            include_default_in_switch = True
+            # TODO(jlocke): implement this to eliminate the unreachable code warning
 
             output = template.render(
                 background_compatible_routes=background_compatible_routes,

--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -247,8 +247,7 @@ class SwiftBackend(SwiftBaseBackend):
             template.globals = template_globals
 
             # don't include the default case in the generated switch statement if it's unreachable
-            include_default_in_switch = \
-                len(background_objc_routes) < len(background_compatible_routes)
+            include_default_in_switch = True # TODO(jlocke): implement this to eliminate the unreachable code warning
 
             output = template.render(
                 background_compatible_routes=background_compatible_routes,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

The logic here was incorrect and the correct logic is non-trivial as it requires knowledge of the specs from an unrelated run of stone (stone generates the Swift client and the SwiftObjc client in separate passes). Since an unneeded default is just an warning while a missing one is an error default to using a default, for now.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?