### PR TITLE
Make custom annotation generation deterministic

### DIFF
--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -701,8 +701,10 @@ class PythonTypesBackend(CodeBackend):
 
             for field in data_type.fields:
                 field_name = fmt_var(field.name, check_reserved=True)
-                for annotation_type, processor in self._generate_custom_annotation_processors(
-                        ns, field.data_type, field.custom_annotations):
+                recursive_processors = list(self._generate_custom_annotation_processors(
+                    ns, field.data_type, field.custom_annotations))
+                recursive_processors = sorted(recursive_processors, key=lambda x: x[0].name)
+                for annotation_type, processor in recursive_processors:
                     annotation_class = class_name_for_annotation_type(annotation_type, ns)
                     self.emit('if annotation_type is {}:'.format(annotation_class))
                     with self.indent():
@@ -990,6 +992,8 @@ class PythonTypesBackend(CodeBackend):
                 # check if we have any annotations that apply to this field at all
                 if len(recursive_processors) == 0:
                     continue
+
+                recursive_processors = sorted(recursive_processors, key=lambda x: x[0].name)
 
                 field_name = fmt_func(field.name)
                 self.emit('if self.is_{}():'.format(field_name))

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -2,7 +2,8 @@
 A command-line interface for StoneAPI.
 """
 
-import importlib
+import importlib.util
+import importlib.machinery
 import io
 import json
 import logging


### PR DESCRIPTION
Changing code which generates python datatypes for stone. This would make custom_annotation related generated code to be deterministic in nature (alphabetic order)

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ X] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?