### PR TITLE
Removing fail_ci_if_error option

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,4 +30,3 @@ jobs:
         uses: codecov/codecov-action@v1.0.14
         with:
           flags: unit
-          fail_ci_if_error: true


### PR DESCRIPTION
Disabling the fail_ci_if_error option for CodeCov since it's not working.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?