### PR TITLE
If a parameter has no properties still rerturn an empty dict not nil

### DIFF
--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -1006,7 +1006,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                         self.emit(
                             'jsonDict[@".tag"] = @"{}";'.format(fmt_var(tag)))
                 self.emit()
-            self.emit('return [jsonDict count] > 0 ? jsonDict : nil;')
+            self.emit('return jsonDict;')
         self.emit()
 
     def _generate_struct_deserializer(self, struct):
@@ -1152,7 +1152,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                     )
 
             self.emit()
-            self.emit('return [jsonDict count] > 0 ? jsonDict : nil;')
+            self.emit('return jsonDict;')
 
         self.emit()
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

If there is a paramater that has no arguments it currently sends that parameter as `nil` which fails stone validation on the server as it still expects that parameter to be provided but as an empty object `{}`, this fixes that.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?