### PR TITLE
fix: Replace deprecated distutils

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -23,7 +23,7 @@ import sys
 import tempfile
 import textwrap
 import zipfile
-from distutils import log
+from setuptools import log
 
 try:
     from site import USER_SITE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ply>= 3.4
 six>= 1.12.0
+packaging>=21.0

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 # See <https://github.com/PyCQA/pylint/issues/73>
-from distutils.version import StrictVersion  # pylint: disable=deprecated-module
+from packaging.version import Version
 
 from .data_types import (
     doc_unwrap,
@@ -34,7 +34,7 @@ class Api:
     """
     def __init__(self, version):
         # type: (str) -> None
-        self.version = StrictVersion(version)
+        self.version = Version(version)
         self.namespaces = OrderedDict()  # type: NamespaceDict
         self.route_schema = None  # type: typing.Optional[Struct]
 

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -282,7 +282,7 @@ int sq(int x) <
         self.assertIsInstance(string_type, String)
 
     def test_preserve_aliases_from_api(self):
-        api = Api(version=None)
+        api = Api(version="0.1b1")
         # Ensure imports come after 'preserve_alias' lexiographicaly
         # to catch namespace ordering bugs
         api.ensure_namespace('preserve_alias')
@@ -390,7 +390,7 @@ int sq(int x) <
         self.assertIsInstance(field.data_type, Alias)
 
     def test_no_preserve_aliases_from_api(self):
-        api = Api(version=None)
+        api = Api(version="0.1b1")
         # Ensure imports come after 'preserve_alias' lexiographicaly
         # to catch namespace ordering bugs
         api.ensure_namespace('preserve_alias')


### PR DESCRIPTION
- **fix: Replace deprecated distutils**
- **fix: conform PEP 440**

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [x] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [x] Have you ran `pytest`?
- [x] Do the tests pass?

It seems `tox` test is broken, I got a lot of failures even though using original code.


Pytest:
```
platform linux -- Python 3.12.3, pytest-8.2.1, pluggy-1.5.0
==== 170 passed, 3 warnings in 10.58s ====
```
