### PR TITLE
Fix background task reconnection route names

### DIFF
--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -25,6 +25,7 @@ from stone.backends.swift_helpers import (
     fmt_func,
     fmt_var,
     fmt_type,
+    fmt_route_name,
     fmt_objc_type,
     mapped_list_info,
     datatype_has_subtypes,
@@ -282,6 +283,7 @@ class SwiftBackend(SwiftBaseBackend):
         return_type = '{}RequestBox'.format(self.args.class_name)
 
         template = self._jinja_template("SwiftReconnectionHelpers.jinja")
+        template.globals['fmt_route_name'] = fmt_route_name
         template.globals['fmt_func'] = fmt_func
         template.globals['fmt_class'] = fmt_class
         template.globals['class_name'] = class_name

--- a/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
+++ b/stone/backends/swift_rsrc/SwiftReconnectionHelpers.jinja
@@ -11,7 +11,7 @@ enum {{ class_name }}: ReconnectionHelpersShared {
 
         switch info.routeName {
         {% for namespace, route in background_compatible_namespace_route_pairs %}
-            case "{{ fmt_func(route.name, route.version) }}":
+            case "{{ fmt_route_name(route) }}":
                 return .{{ fmt_func(route.name, route.version) }}(
                     rebuildRequest(
                         apiRequest: apiRequest,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Background task reconnection is keyed by route name. We have a few ways of processing these for different uses, e.g., `upload_session/start` in a route spec versus `uploadSessionStart` in a the route function name. We were keying on the wrong one of these for route reconnection, which worked only for the simplest route names, like upload and download. This PR standardizes reconnection route names with the route names written into these tasks.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [X] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [X] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [X] Do the tests pass?