### PR TITLE
[WIP] Disable old python versions for macOS latest runner

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -14,7 +14,7 @@ jobs:
         python-version: [3.8, 3.11, pypy-3.7]
         include:
           - os: ubuntu-20.04
-            python-version: [3.6]
+            python-version: 3.6
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,10 +11,14 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-20.04]
-        python-version: [3.8, 3.11, pypy-3.7]
+        python-version: [3.8, 3.11]
         include:
           - os: ubuntu-20.04
             python-version: 3.6
+          - os: ubuntu-20.04
+            python-version: pypy-3.7
+          - os: macos-latest
+            python-version: pypy-3.10
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-20.04]
         python-version: [3.6, 3.8, 3.11, pypy-3.7]
+        exclude:
+          - os: macos-latest
+            python-version: [3.6]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-20.04]
-        python-version: [3.6, 3.8, 3.11, pypy-3.7]
-        exclude:
-          - os: macos-latest
+        python-version: [3.8, 3.11, pypy-3.7]
+        include:
+          - os: ubuntu-20.04
             python-version: [3.6]
     steps:
       - uses: actions/checkout@v2

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -640,10 +640,12 @@ class PythonTypesBackend(CodeBackend):
         dt, _, _ = unwrap(data_type)
         if is_struct_type(dt) or is_union_type(dt):
             annotation_types_seen = set()
-            # If data type enumerates subtypes, recurse to subtypes instead which in turn collect parents' custom annotations
+            # If data type enumerates subtypes, recurse to subtypes instead which in turn collect
+            # parents' custom annotations
             if is_struct_type(dt) and dt.has_enumerated_subtypes():
                 for subtype in dt.get_enumerated_subtypes():
-                    for annotation_type, recursive_processor in self._generate_custom_annotation_processors(ns, subtype.data_type):
+                    for annotation_type, recursive_processor in \
+                    self._generate_custom_annotation_processors(ns, subtype.data_type):
                         if annotation_type not in annotation_types_seen:
                             yield (annotation_type, recursive_processor)
                             annotation_types_seen.add(annotation_type)
@@ -653,8 +655,10 @@ class PythonTypesBackend(CodeBackend):
                         yield (annotation.annotation_type,
                                generate_func_call(
                                    'bb.make_struct_annotation_processor',
-                                   args=[class_name_for_annotation_type(annotation.annotation_type, ns),
-                                         'processor']
+                                   args=[
+                                        class_name_for_annotation_type(
+                                            annotation.annotation_type, ns),
+                                        'processor']
                                ))
                         annotation_types_seen.add(annotation.annotation_type)
         elif is_list_type(dt):

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -645,7 +645,7 @@ class PythonTypesBackend(CodeBackend):
             if is_struct_type(dt) and dt.has_enumerated_subtypes():
                 for subtype in dt.get_enumerated_subtypes():
                     for annotation_type, recursive_processor in \
-                    self._generate_custom_annotation_processors(ns, subtype.data_type):
+                            self._generate_custom_annotation_processors(ns, subtype.data_type):
                         if annotation_type not in annotation_types_seen:
                             yield (annotation_type, recursive_processor)
                             annotation_types_seen.add(annotation_type)
@@ -656,9 +656,9 @@ class PythonTypesBackend(CodeBackend):
                                generate_func_call(
                                    'bb.make_struct_annotation_processor',
                                    args=[
-                                        class_name_for_annotation_type(
-                                            annotation.annotation_type, ns),
-                                        'processor']
+                                       class_name_for_annotation_type(
+                                           annotation.annotation_type, ns),
+                                       'processor']
                                ))
                         annotation_types_seen.add(annotation.annotation_type)
         elif is_list_type(dt):


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
On latest macOS setting up python 3.6 errors with version 3.6 was not found in the local cache. This disables 3.6 tests on macOS while leaving them enabled on linux.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?