### PR TITLE
MF-5759 fix unstable route order for routes with same name but different versions

### DIFF
--- a/stone/frontend/ir_generator.py
+++ b/stone/frontend/ir_generator.py
@@ -1704,10 +1704,6 @@ class IRGenerator:
             namespace.route_by_name = {}
             namespace.routes_by_name = {}
 
-            # We need a stable sort in order to keep the resultant output
-            # the same across runs.
-            routes.sort()
-
             for route in routes:
                 namespace.add_route(route)
 

--- a/stone/ir/api.py
+++ b/stone/ir/api.py
@@ -328,9 +328,9 @@ class ApiNamespace:
     def normalize(self):
         # type: () -> None
         """
-        Alphabetizes routes to make route declaration order irrelevant.
+        Sorts routes to make route declaration order irrelevant.
         """
-        self.routes.sort(key=lambda route: route.name)
+        self.routes.sort()
         self.data_types.sort(key=lambda data_type: data_type.name)
         self.aliases.sort(key=lambda alias: alias.name)
         self.annotations.sort(key=lambda annotation: annotation.name)
@@ -411,9 +411,9 @@ class ApiRoute:
         if not isinstance(rhs, ApiRoute):
             raise TypeError("Expected ApiRoute for object: {}".format(rhs))
 
-        if lhs.name < rhs.name or lhs.version < rhs.version:
+        if (lhs.name, lhs.version) < (rhs.name, rhs.version):
             return -1
-        elif lhs.name > rhs.name or lhs.version > rhs.version:
+        elif (lhs.name, lhs.version) > (rhs.name, rhs.version):
             return 1
         else:
             return 0

--- a/test/test_api_route.py
+++ b/test/test_api_route.py
@@ -1,0 +1,23 @@
+import unittest
+
+from stone.ir import ApiRoute
+
+
+class TestApiRoute(unittest.TestCase):
+    def test_stable_sort(self):
+        """
+        Tests API Route sorts according to name and then version
+        """
+        routes = [
+            ApiRoute("B", 1, None),
+            ApiRoute("A", 2, None),
+            ApiRoute("A", 1, None),
+            ApiRoute("B", 2, None),
+        ]
+
+        expected = [("A", 1), ("A", 2), ("B", 1), ("B", 2)]
+        sorted_routes = list(map(lambda x: (x.name, x.version), sorted(routes)))
+        self.assertEqual(sorted_routes, expected)
+
+        reversed_sorted_routes = list(map(lambda x: (x.name, x.version), sorted(reversed(routes))))
+        self.assertEqual(reversed_sorted_routes, expected)


### PR DESCRIPTION
Looks like there was a previous attempt at this, but it's still unstable
https://github.com/dropbox/stone/pull/260/files

I fixed the compare method added there and removed the sort that was added in favor of updating the existing normalize method to also sort by version


<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?