### PR TITLE
Fix unreachable code warnings when all reconnectable swift routes have compat wrappers

### DIFF
--- a/stone/backends/swift_client.py
+++ b/stone/backends/swift_client.py
@@ -251,15 +251,10 @@ class SwiftBackend(SwiftBaseBackend):
             template = self._jinja_template("ObjCRequestBox.jinja")
             template.globals = template_globals
 
-            # don't include the default case in the generated switch statement if it's unreachable
-            include_default_in_switch = True
-            # TODO(jlocke): implement this to eliminate the unreachable code warning
-
             output = template.render(
                 background_compatible_routes=background_compatible_routes,
                 background_objc_routes=background_objc_routes,
-                class_name=swift_class_name,
-                include_default_in_switch=include_default_in_switch
+                class_name=swift_class_name
             )
 
             file_name = 'DBX{}RequestBox.swift'.format(self.args.class_name)

--- a/stone/backends/swift_rsrc/ObjCRequestBox.jinja
+++ b/stone/backends/swift_rsrc/ObjCRequestBox.jinja
@@ -9,18 +9,16 @@ import SwiftyDropbox
 
 extension {{ class_name }} {
     var objc: DBXRequest {
-        switch self {
-            {% for route_args_data in background_objc_routes %}
-            {% set namespace = route_args_data[0] %}
-            {% set route = route_args_data[1] %}
-            {% set args_data = route_args_data[2] %}
-            case .{{ fmt_func_namespace(route.name, route.version, namespace.name) }}(let swift):
-                return {{ fmt_route_objc_class(namespace, route, args_data) }}(swift: swift)
-            {% endfor %}
-            {% if include_default_in_switch %}
-            default:
-                fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
-            {% endif %}
+        {% for route_args_data in background_objc_routes %}
+        {% set namespace = route_args_data[0] %}
+        {% set route = route_args_data[1] %}
+        {% set args_data = route_args_data[2] %}
+        if case .{{ fmt_func_namespace(route.name, route.version, namespace.name) }}(let swift) = self {
+            return {{ fmt_route_objc_class(namespace, route, args_data) }}(swift: swift)
+        }
+        {% endfor %}
+        else {
+            fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Background compatible routes get generated reconnection wrapper types. If they're in the allow list for Objective-C compatibility generation as well, an additional Objective-C wrapper type will be generated. If we generate an Objective C compatibility wrapper for each Swift one, a switch statement used to map from one to the other will contain an unreachable default statement. Since each layer is generated in separate (and potentially parallel) code generation passes, it's difficult make the generation logic smart enough to know whether to include the default. This change eliminates the warning by generating a different control flow that accommodates both situations naturally.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?