### PR TITLE
Fix hash and client var name collision errors

### DIFF
--- a/stone/backends/swift_helpers.py
+++ b/stone/backends/swift_helpers.py
@@ -99,6 +99,8 @@ _reserved_words = {
     'typealias',
     'var',
     'default',
+    'hash',
+    'client',
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

There are a few new variable names that must be suffixed with `_` to avoid collisions in the SwiftyDropbox Objective-C compatibility layer: hash (colliding with the NSObject var) and client (colliding with our own client vars).

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [ ] Do the tests pass?