### PR TITLE
Remove pytest-runner / setup.py test support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We are more than happy to receive pull requests helping us improve the state of 
 Tests live under the `test/` folder. They can be run by running the following command:
 
 ```
-$ python setup.py test
+$ pytest
 ```
 
 They can also be run as a part of `tox` and they should be ran in a virtual environment to ensure isolation of the testing environment.

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,6 @@ install_reqs = []
 with open('requirements.txt') as f:  # pylint: disable=W1514
     install_reqs += f.read().splitlines()
 
-setup_requires = [
-    'pytest-runner == 5.3.2',
-]
-
-# WARNING: This imposes limitations on test/requirements.txt such that the
-# full Pip syntax is not supported. See also
-# <http://stackoverflow.com/questions/14399534/>.
-test_reqs = []
-with open('test/requirements.txt') as f:  # pylint: disable=W1514
-    test_reqs += f.read().splitlines()
-
 with open('README.rst') as f:  # pylint: disable=W1514
     README = f.read()
 
@@ -38,8 +27,6 @@ dist = setup(
     name='stone',
     version='3.3.9',
     install_requires=install_reqs,
-    setup_requires=setup_requires,
-    tests_require=test_reqs,
     entry_points={
         'console_scripts': ['stone=stone.cli:main'],
     },


### PR DESCRIPTION
Removes `pytest-runner` from `setup_requires`, and remove `test_requires`, which is deprecated and only useful with `setup.py test`.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with `pytest` or `tox`.

Fixes #344.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?