### PR TITLE
Fix invalid exception syntax: use tuple instead of list in HashRedactor

### DIFF
--- a/stone/backends/python_rsrc/stone_validators.py
+++ b/stone/backends/python_rsrc/stone_validators.py
@@ -711,7 +711,7 @@ class HashRedactor(Redactor):
         try:
             # add string literal to ensure unicode
             hashed = hashlib.md5(val_to_hash.encode('utf-8')).hexdigest() + ''
-        except [AttributeError, ValueError]:
+        except (AttributeError, ValueError):
             hashed = None
 
         if matches:


### PR DESCRIPTION
## Summary

This PR fixes a bug in `stone/backends/python_rsrc/stone_validators.py` where an except clause was using list syntax instead of tuple syntax for catching multiple exceptions.

## The Bug

On line 714, the code was:
```python
except [AttributeError, ValueError]:
```

This is invalid Python syntax. When Python attempts to execute this code, it raises:
```
TypeError: catching classes that do not inherit from BaseException is not allowed
```

## The Fix

Changed to proper tuple syntax:
```python
except (AttributeError, ValueError):
```

## Verification

```python
# Before (broken)
try:
    raise ValueError('test')
except [ValueError, AttributeError]:  # TypeError!
    print('caught')

# After (working)
try:
    raise ValueError('test')
except (ValueError, AttributeError):  # Works correctly
    print('caught')
```

## Impact

This bug would cause `HashRedactor.apply()` to fail entirely whenever an `AttributeError` or `ValueError` is raised during hashing, preventing proper redaction of sensitive data.