### PR TITLE
Add native Stone manifest support

### DIFF
--- a/stone/backend.py
+++ b/stone/backend.py
@@ -2,6 +2,7 @@ import argparse
 import io
 import logging
 import os
+import shutil
 import textwrap
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
@@ -22,6 +23,35 @@ if _MYPY:
     DelimTuple = typing.Tuple[str, str]
     K = typing.TypeVar('K')
     V = typing.TypeVar('V')
+
+
+def _relative_output_path(output_root, output_path):
+    # type: (str, str) -> str
+    root_path = os.path.abspath(output_root)
+    full_path = os.path.abspath(output_path)
+    relative_path = os.path.relpath(full_path, root_path)
+    if (relative_path == os.pardir or
+            relative_path.startswith(os.pardir + os.sep) or
+            os.path.isabs(relative_path)):
+        raise AssertionError(
+            'Stone attempted to write outside its output root: {}'.format(full_path))
+    return relative_path.replace(os.sep, '/')
+
+
+class OutputManifest:
+    """Collects generated output paths without writing their contents."""
+
+    def __init__(self):
+        # type: () -> None
+        self._outputs = set()  # type: typing.Set[str]
+
+    def add_output(self, output_root, output_path):
+        # type: (str, str) -> None
+        self._outputs.add(_relative_output_path(output_root, output_path))
+
+    def outputs(self):
+        # type: () -> typing.List[str]
+        return sorted(self._outputs)
 
 
 def remove_aliases_from_api(api):
@@ -97,8 +127,8 @@ class Backend(metaclass=ABCMeta):
     # For backwards compatibility with existing backends defaults to false.
     preserve_aliases = False
 
-    def __init__(self, target_folder_path, args):
-        # type: (str, typing.Optional[typing.Sequence[str]]) -> None
+    def __init__(self, target_folder_path, args, output_manifest=None):
+        # type: (str, typing.Optional[typing.Sequence[str]], typing.Optional[OutputManifest]) -> None  # noqa: E501
         """
         Args:
             target_folder_path (str): Path to the folder where all generated
@@ -116,6 +146,7 @@ class Backend(metaclass=ABCMeta):
         self.named_placeholders = {}  # type: typing.Dict[typing.Text, typing.Text]
 
         self.args = None  # type: typing.Optional[argparse.Namespace]
+        self.output_manifest = output_manifest
 
         if self.cmdline_parser:
             assert isinstance(self.cmdline_parser, argparse.ArgumentParser), (
@@ -140,6 +171,13 @@ class Backend(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def _record_output_path(self, output_path):
+        # type: (str) -> bool
+        if self.output_manifest is None:
+            return False
+        self.output_manifest.add_output(self.target_folder_path, output_path)
+        return True
+
     @contextmanager
     def output_to_relative_path(self, relative_path, mode='wb'):
         # type: (typing.Text, typing.Text) -> typing.Iterator[None]
@@ -150,6 +188,12 @@ class Backend(metaclass=ABCMeta):
         Clears the output buffer on enter and exit.
         """
         full_path = os.path.join(self.target_folder_path, relative_path)
+        if self._record_output_path(full_path):
+            self.clear_output_buffer()
+            yield
+            self.clear_output_buffer()
+            return
+
         directory = os.path.dirname(full_path)
         if not os.path.exists(directory):
             self.logger.info('Creating %s', directory)
@@ -161,6 +205,12 @@ class Backend(metaclass=ABCMeta):
         with open(full_path, mode) as f:  # pylint: disable=unspecified-encoding
             f.write(self.output_buffer_to_string().encode('utf-8'))
         self.clear_output_buffer()
+
+    def copy_to_path(self, src, dst, *copy_args, **copy_kwargs):
+        output_path = os.path.join(dst, os.path.basename(src)) if os.path.isdir(dst) else dst
+        if self._record_output_path(output_path):
+            return output_path
+        return shutil.copy(src, dst, *copy_args, **copy_kwargs)
 
     def output_buffer_to_string(self):
         # type: () -> typing.Text

--- a/stone/backend.py
+++ b/stone/backend.py
@@ -178,6 +178,10 @@ class Backend(metaclass=ABCMeta):
         self.output_manifest.add_output(self.target_folder_path, output_path)
         return True
 
+    def _validate_output_path(self, output_path):
+        # type: (str) -> None
+        _relative_output_path(self.target_folder_path, output_path)
+
     @contextmanager
     def output_to_relative_path(self, relative_path, mode='wb'):
         # type: (typing.Text, typing.Text) -> typing.Iterator[None]
@@ -188,6 +192,7 @@ class Backend(metaclass=ABCMeta):
         Clears the output buffer on enter and exit.
         """
         full_path = os.path.join(self.target_folder_path, relative_path)
+        self._validate_output_path(full_path)
         if self._record_output_path(full_path):
             self.clear_output_buffer()
             yield
@@ -208,6 +213,7 @@ class Backend(metaclass=ABCMeta):
 
     def copy_to_path(self, src, dst, *copy_args, **copy_kwargs):
         output_path = os.path.join(dst, os.path.basename(src)) if os.path.isdir(dst) else dst
+        self._validate_output_path(output_path)
         if self._record_output_path(output_path):
             return output_path
         return shutil.copy(src, dst, *copy_args, **copy_kwargs)

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 
 import six
 
@@ -99,26 +98,26 @@ class ObjCTypesBackend(ObjCBaseBackend):
             os.makedirs(rsrc_output_folder)
 
         self.logger.info('Copying DBStoneValidators.{h,m} to output folder')
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBStoneValidators.h'),
             rsrc_output_folder)
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBStoneValidators.m'),
             rsrc_output_folder)
         self.logger.info('Copying DBStoneSerializers.{h,m} to output folder')
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBStoneSerializers.h'),
             rsrc_output_folder)
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBStoneSerializers.m'),
             rsrc_output_folder)
         self.logger.info('Copying DBStoneBase.{h,m} to output folder')
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBStoneBase.h'), rsrc_output_folder)
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBStoneBase.m'), rsrc_output_folder)
         self.logger.info('Copying DBSerializableProtocol.h to output folder')
-        shutil.copy(
+        self.copy_to_path(
             os.path.join(rsrc_folder, 'DBSerializableProtocol.h'),
             rsrc_output_folder)
 

--- a/stone/backends/swift.py
+++ b/stone/backends/swift.py
@@ -270,6 +270,7 @@ class SwiftBaseBackend(CodeBackend):
         if not os.path.exists(full_path):
             os.mkdir(full_path)
         full_path = os.path.join(full_path, file_name)
+        self._validate_output_path(full_path)
         if self._record_output_path(full_path):
             return
         with open(full_path, "w", encoding='utf-8') as fh:

--- a/stone/backends/swift.py
+++ b/stone/backends/swift.py
@@ -270,6 +270,8 @@ class SwiftBaseBackend(CodeBackend):
         if not os.path.exists(full_path):
             os.mkdir(full_path)
         full_path = os.path.join(full_path, file_name)
+        if self._record_output_path(full_path):
+            return
         with open(full_path, "w", encoding='utf-8') as fh:
             fh.write(output)
 

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 
 import six
 import jinja2
@@ -140,14 +139,14 @@ class SwiftTypesBackend(SwiftBaseBackend):
         rsrc_folder = os.path.join(os.path.dirname(__file__), 'swift_rsrc')
         if not self.args.objc:
             self.logger.info('Copying StoneValidators.swift to output folder')
-            shutil.copy(os.path.join(rsrc_folder, 'StoneValidators.swift'),
-                        self.target_folder_path)
+            self.copy_to_path(os.path.join(rsrc_folder, 'StoneValidators.swift'),
+                              self.target_folder_path)
             self.logger.info('Copying StoneSerializers.swift to output folder')
-            shutil.copy(os.path.join(rsrc_folder, 'StoneSerializers.swift'),
-                        self.target_folder_path)
+            self.copy_to_path(os.path.join(rsrc_folder, 'StoneSerializers.swift'),
+                              self.target_folder_path)
             self.logger.info('Copying StoneBase.swift to output folder')
-            shutil.copy(os.path.join(rsrc_folder, 'StoneBase.swift'),
-                        self.target_folder_path)
+            self.copy_to_path(os.path.join(rsrc_folder, 'StoneBase.swift'),
+                              self.target_folder_path)
 
         template_loader = jinja2.FileSystemLoader(searchpath=rsrc_folder)
         template_env = jinja2.Environment(loader=template_loader,

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -86,6 +86,11 @@ _cmdline_parser.add_argument(
           'generated source file contents.'),
 )
 _cmdline_parser.add_argument(
+    '--expected-output-manifest',
+    type=str,
+    help='JSON file containing the exact relative output paths Stone must produce.',
+)
+_cmdline_parser.add_argument(
     '--clean-build',
     action='store_true',
     help='The path to the template SDK for the target language.',
@@ -139,6 +144,42 @@ _filter_ns_group.add_argument(
     default=[],
     help='If set, backends will not see any routes for the specified namespaces.',
 )
+
+def _actual_outputs(output_root):
+    # type: (str) -> typing.List[str]
+    outputs = []
+    for root, _, file_names in os.walk(output_root):
+        for file_name in file_names:
+            output_path = os.path.join(root, file_name)
+            relpath = os.path.relpath(output_path, output_root).replace(os.sep, '/')
+            outputs.append(relpath)
+    return sorted(outputs)
+
+
+def _load_expected_output_manifest(path):
+    # type: (str) -> typing.List[str]
+    with open(path, encoding='utf-8') as manifest_file:
+        data = json.load(manifest_file)
+    if not isinstance(data, list) or not all(isinstance(item, str) for item in data):
+        _cmdline_parser.error(
+            '--expected-output-manifest must be a JSON list of strings: {}'.format(path))
+    return sorted(data)
+
+
+def _validate_expected_output_manifest(expected, actual):
+    # type: (typing.List[str], typing.List[str]) -> None
+    if actual == expected:
+        return
+
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    print(
+        'error: Stone output manifest mismatch.\nMissing: {}\nExtra: {}'.format(
+            missing,
+            extra),
+        file=sys.stderr)
+    sys.exit(1)
+
 
 def main():
     """The entry point for the program."""
@@ -361,8 +402,20 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
+    if args.output_manifest or args.expected_output_manifest:
+        if args.output_manifest:
+            actual_manifest = c.output_manifest()
+        else:
+            actual_manifest = _actual_outputs(args.output)
+    else:
+        actual_manifest = None
+
+    if args.expected_output_manifest:
+        expected_manifest = _load_expected_output_manifest(args.expected_output_manifest)
+        _validate_expected_output_manifest(expected_manifest, actual_manifest)
+
     if args.output_manifest:
-        print(json.dumps(c.output_manifest(), indent=2))
+        print(json.dumps(actual_manifest, indent=2))
 
     if not sys.argv[0].endswith('stone'):
         # If we aren't running from an entry_point, then return api to make it

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -91,6 +91,11 @@ _cmdline_parser.add_argument(
     help='JSON file containing the exact relative output paths Stone must produce.',
 )
 _cmdline_parser.add_argument(
+    '--recursive',
+    action='store_true',
+    help='Recursively expand directory specification arguments into .stone files.',
+)
+_cmdline_parser.add_argument(
     '--clean-build',
     action='store_true',
     help='The path to the template SDK for the target language.',
@@ -144,6 +149,16 @@ _filter_ns_group.add_argument(
     default=[],
     help='If set, backends will not see any routes for the specified namespaces.',
 )
+
+def _recursive_stone_specs(spec_root):
+    # type: (str) -> typing.List[str]
+    spec_paths = []
+    for root, _, file_names in os.walk(spec_root):
+        for file_name in file_names:
+            if file_name.endswith('.stone'):
+                spec_paths.append(os.path.join(root, file_name))
+    return sorted(spec_paths)
+
 
 def _actual_outputs(output_root):
     # type: (str) -> typing.List[str]
@@ -224,6 +239,10 @@ def main():
             for spec_path in args.spec:
                 if spec_path == '-':
                     read_from_stdin = True
+                elif os.path.isdir(spec_path) and args.recursive:
+                    for recursive_spec_path in _recursive_stone_specs(spec_path):
+                        with open(recursive_spec_path, encoding='utf-8') as f:
+                            specs.append((recursive_spec_path, f.read()))
                 elif not spec_path.endswith('.stone'):
                     print("error: Specification '%s' must have a .stone extension."
                           % spec_path,

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -80,6 +80,12 @@ _cmdline_parser.add_argument(
           'specs together.'),
 )
 _cmdline_parser.add_argument(
+    '--output-manifest',
+    action='store_true',
+    help=('Print a JSON manifest of generated output paths instead of writing '
+          'generated source file contents.'),
+)
+_cmdline_parser.add_argument(
     '--clean-build',
     action='store_true',
     help='The path to the template SDK for the target language.',
@@ -345,6 +351,7 @@ def main():
         backend_args,
         args.output,
         clean_build=args.clean_build,
+        output_manifest=args.output_manifest,
     )
     try:
         c.build()
@@ -353,6 +360,9 @@ def main():
               (args.backend, e.backend_name, e.traceback),
               file=sys.stderr)
         sys.exit(1)
+
+    if args.output_manifest:
+        print(json.dumps(c.output_manifest(), indent=2))
 
     if not sys.argv[0].endswith('stone'):
         # If we aren't running from an entry_point, then return api to make it

--- a/stone/compiler.py
+++ b/stone/compiler.py
@@ -6,6 +6,7 @@ import traceback
 
 from stone.backend import (
     Backend,
+    OutputManifest,
     remove_aliases_from_api,
 )
 
@@ -36,7 +37,8 @@ class Compiler:
                  backend_module,
                  backend_args,
                  build_path,
-                 clean_build=False):
+                 clean_build=False,
+                 output_manifest=False):
         """
         Creates a Compiler.
 
@@ -50,6 +52,8 @@ class Compiler:
             source files are compiled into the same directories.
         :param bool clean_build: If True, the build_path is removed before
             source files are compiled into them.
+        :param bool output_manifest: If True, record generated output paths
+            without writing generated file contents.
         """
         self._logger = logging.getLogger('stone.compiler')
 
@@ -57,6 +61,7 @@ class Compiler:
         self.backend_module = backend_module
         self.backend_args = backend_args
         self.build_path = build_path
+        self._output_manifest = OutputManifest() if output_manifest else None
 
         # Remove existing build directory if it's a clean build
         if clean_build and os.path.exists(self.build_path):
@@ -71,6 +76,12 @@ class Compiler:
             return
         Compiler._mkdir(self.build_path)
         self._execute_backend_on_spec()
+
+    def output_manifest(self):
+        """Returns generated output paths recorded during a manifest build."""
+        if self._output_manifest is None:
+            return []
+        return self._output_manifest.outputs()
 
     @staticmethod
     def _mkdir(path):
@@ -106,6 +117,7 @@ class Compiler:
                     not inspect.isabstract(attr_value)):
                 self._logger.info('Running backend: %s', attr_value.__name__)
                 backend = attr_value(self.build_path, self.backend_args)
+                backend.output_manifest = self._output_manifest
 
                 if backend.preserve_aliases:
                     api = self.api

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,6 +9,7 @@ import unittest
 from stone.cli import (
     _actual_outputs,
     _load_expected_output_manifest,
+    _recursive_stone_specs,
     _validate_expected_output_manifest,
 )
 from stone.cli_helpers import parse_route_attr_filter
@@ -148,6 +149,23 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(
                 _actual_outputs(output_root),
                 ['Generated.py', 'nested/Generated.swift'])
+
+    def test_recursive_stone_specs(self):
+        with tempfile.TemporaryDirectory() as spec_root:
+            os.makedirs(os.path.join(spec_root, 'nested'))
+            with open(os.path.join(spec_root, 'top.stone'), 'w', encoding='utf-8'):
+                pass
+            with open(os.path.join(spec_root, 'nested', 'child.stone'), 'w', encoding='utf-8'):
+                pass
+            with open(os.path.join(spec_root, 'nested', 'ignored.txt'), 'w', encoding='utf-8'):
+                pass
+
+            self.assertEqual(
+                _recursive_stone_specs(spec_root),
+                [
+                    os.path.join(spec_root, 'nested', 'child.stone'),
+                    os.path.join(spec_root, 'top.stone'),
+                ])
 
     def test_load_expected_output_manifest(self):
         with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as manifest_file:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
 
 
+import json
+import os
+import tempfile
 import unittest
 
+from stone.cli import (
+    _actual_outputs,
+    _load_expected_output_manifest,
+    _validate_expected_output_manifest,
+)
 from stone.cli_helpers import parse_route_attr_filter
 
 
@@ -125,6 +133,34 @@ class TestCLI(unittest.TestCase):
         self.assertTrue(expr.eval(MockRoute({'a': 2, 'b': 3, 'c': 4})))
         self.assertFalse(expr.eval(MockRoute({'a': 1})))
         self.assertFalse(expr.eval(MockRoute({'a': 1, 'b': 3})))
+
+    def test_actual_outputs(self):
+        with tempfile.TemporaryDirectory() as output_root:
+            os.makedirs(os.path.join(output_root, 'nested'))
+            with open(os.path.join(output_root, 'Generated.py'), 'w', encoding='utf-8'):
+                pass
+            with open(
+                    os.path.join(output_root, 'nested', 'Generated.swift'),
+                    'w',
+                    encoding='utf-8'):
+                pass
+
+            self.assertEqual(
+                _actual_outputs(output_root),
+                ['Generated.py', 'nested/Generated.swift'])
+
+    def test_load_expected_output_manifest(self):
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as manifest_file:
+            json.dump(['b.py', 'a.py'], manifest_file)
+            manifest_file.flush()
+
+            self.assertEqual(_load_expected_output_manifest(manifest_file.name), ['a.py', 'b.py'])
+
+    def test_validate_expected_output_manifest(self):
+        _validate_expected_output_manifest(['a.py'], ['a.py'])
+
+        with self.assertRaises(SystemExit):
+            _validate_expected_output_manifest(['a.py'], ['b.py'])
 
 
 if __name__ == '__main__':

--- a/test/test_output_manifest.py
+++ b/test/test_output_manifest.py
@@ -74,5 +74,53 @@ class TestOutputManifest(unittest.TestCase):
         self.assertEqual(existing_files, [])
 
 
+class TestOutputRootValidation(unittest.TestCase):
+
+    def test_output_to_relative_path_rejects_parent_paths(self):
+        class ValidatingBackend(CodeBackend):
+            preserve_aliases = True
+
+            def generate(self, api):
+                pass
+
+        with tempfile.TemporaryDirectory() as output_root:
+            backend = ValidatingBackend(output_root, [])
+
+            with self.assertRaises(AssertionError):
+                with backend.output_to_relative_path('../Generated.py'):
+                    backend.emit('generated = True')
+
+    def test_copy_to_path_rejects_parent_paths(self):
+        class ValidatingBackend(Backend):
+            preserve_aliases = True
+
+            def generate(self, api):
+                pass
+
+        with tempfile.NamedTemporaryFile() as source_file:
+            with tempfile.TemporaryDirectory() as output_root:
+                backend = ValidatingBackend(output_root, [])
+
+                with self.assertRaises(AssertionError):
+                    backend.copy_to_path(
+                        source_file.name,
+                        os.path.join(output_root, '..', 'Copied.py'))
+
+    def test_swift_output_rejects_parent_paths(self):
+        class ValidatingBackend(SwiftBaseBackend):
+            preserve_aliases = True
+
+            def generate(self, api):
+                pass
+
+        with tempfile.TemporaryDirectory() as output_root:
+            backend = ValidatingBackend(output_root, [])
+
+            with self.assertRaises(AssertionError):
+                backend._write_output_in_target_folder(
+                    'final class Generated {}',
+                    '../Generated.swift')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_output_manifest.py
+++ b/test/test_output_manifest.py
@@ -1,0 +1,78 @@
+import os
+import tempfile
+import types
+import unittest
+
+from stone.backend import Backend, CodeBackend
+from stone.backends.swift import SwiftBaseBackend
+from stone.compiler import Compiler
+
+
+class TestOutputManifest(unittest.TestCase):
+
+    def _build_manifest(self, backend_cls):
+        module = types.ModuleType('manifest_backend')
+        setattr(module, backend_cls.__name__, backend_cls)
+
+        with tempfile.TemporaryDirectory() as output_root:
+            compiler = Compiler(
+                None,
+                module,
+                [],
+                output_root,
+                output_manifest=True)
+            compiler.build()
+            existing_files = []
+            for root, _, file_names in os.walk(output_root):
+                for file_name in file_names:
+                    existing_files.append(
+                        os.path.relpath(os.path.join(root, file_name), output_root))
+            return compiler.output_manifest(), sorted(existing_files)
+
+    def test_output_to_relative_path_records_without_writing(self):
+
+        class ManifestBackend(CodeBackend):
+            preserve_aliases = True
+
+            def generate(self, api):
+                with self.output_to_relative_path('Generated.py'):
+                    self.emit('generated = True')
+
+        manifest, existing_files = self._build_manifest(ManifestBackend)
+
+        self.assertEqual(manifest, ['Generated.py'])
+        self.assertEqual(existing_files, [])
+
+    def test_copy_to_path_records_destination_without_copying(self):
+        with tempfile.NamedTemporaryFile() as source_file:
+
+            class CopyBackend(Backend):
+                preserve_aliases = True
+                src_path = source_file.name
+
+                def generate(self, api):
+                    resources_path = os.path.join(self.target_folder_path, 'Resources')
+                    os.makedirs(resources_path)
+                    self.copy_to_path(self.src_path, resources_path)
+
+            manifest, existing_files = self._build_manifest(CopyBackend)
+
+        self.assertEqual(manifest, ['Resources/{}'.format(os.path.basename(source_file.name))])
+        self.assertEqual(existing_files, [])
+
+    def test_swift_output_records_without_writing(self):
+
+        class SwiftBackend(SwiftBaseBackend):
+            preserve_aliases = True
+
+            def generate(self, api):
+                self._write_output_in_target_folder('final class Generated {}', 'Generated.swift')
+
+        manifest, existing_files = self._build_manifest(SwiftBackend)
+
+        self.assertEqual(manifest, ['Generated.swift'])
+        self.assertEqual(existing_files, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Adds the native Stone manifest support that xplat needs:

- `--output-manifest` to report generated output paths without writing generated file contents.
- Default validation that backend writes stay under the configured output root.
- `--expected-output-manifest` to compare generated output paths against a checked manifest.
- `--recursive` so directory spec arguments expand to `.stone` files.

This PR now includes the landed middle stack changes so the remaining stack can land cleanly.

## **Checklist**

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [x] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [x] Do the tests pass?

Verification run directly with the CI lint/test steps:
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with flake8==5.0.4 --with pylint flake8 setup.py example stone test`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with flake8==5.0.4 --with pylint --with setuptools pylint --rcfile=.pylintrc setup.py example stone test`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with pytest --with mock pytest`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with enum34 --with mypy --with types-six ./mypy-run.sh`
