### PR TITLE
Support recursive spec directory arguments

### DIFF
--- a/stone/cli.py
+++ b/stone/cli.py
@@ -91,6 +91,11 @@ _cmdline_parser.add_argument(
     help='JSON file containing the exact relative output paths Stone must produce.',
 )
 _cmdline_parser.add_argument(
+    '--recursive',
+    action='store_true',
+    help='Recursively expand directory specification arguments into .stone files.',
+)
+_cmdline_parser.add_argument(
     '--clean-build',
     action='store_true',
     help='The path to the template SDK for the target language.',
@@ -144,6 +149,16 @@ _filter_ns_group.add_argument(
     default=[],
     help='If set, backends will not see any routes for the specified namespaces.',
 )
+
+def _recursive_stone_specs(spec_root):
+    # type: (str) -> typing.List[str]
+    spec_paths = []
+    for root, _, file_names in os.walk(spec_root):
+        for file_name in file_names:
+            if file_name.endswith('.stone'):
+                spec_paths.append(os.path.join(root, file_name))
+    return sorted(spec_paths)
+
 
 def _actual_outputs(output_root):
     # type: (str) -> typing.List[str]
@@ -224,6 +239,10 @@ def main():
             for spec_path in args.spec:
                 if spec_path == '-':
                     read_from_stdin = True
+                elif os.path.isdir(spec_path) and args.recursive:
+                    for recursive_spec_path in _recursive_stone_specs(spec_path):
+                        with open(recursive_spec_path, encoding='utf-8') as f:
+                            specs.append((recursive_spec_path, f.read()))
                 elif not spec_path.endswith('.stone'):
                     print("error: Specification '%s' must have a .stone extension."
                           % spec_path,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,6 +9,7 @@ import unittest
 from stone.cli import (
     _actual_outputs,
     _load_expected_output_manifest,
+    _recursive_stone_specs,
     _validate_expected_output_manifest,
 )
 from stone.cli_helpers import parse_route_attr_filter
@@ -148,6 +149,23 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(
                 _actual_outputs(output_root),
                 ['Generated.py', 'nested/Generated.swift'])
+
+    def test_recursive_stone_specs(self):
+        with tempfile.TemporaryDirectory() as spec_root:
+            os.makedirs(os.path.join(spec_root, 'nested'))
+            with open(os.path.join(spec_root, 'top.stone'), 'w', encoding='utf-8'):
+                pass
+            with open(os.path.join(spec_root, 'nested', 'child.stone'), 'w', encoding='utf-8'):
+                pass
+            with open(os.path.join(spec_root, 'nested', 'ignored.txt'), 'w', encoding='utf-8'):
+                pass
+
+            self.assertEqual(
+                _recursive_stone_specs(spec_root),
+                [
+                    os.path.join(spec_root, 'nested', 'child.stone'),
+                    os.path.join(spec_root, 'top.stone'),
+                ])
 
     def test_load_expected_output_manifest(self):
         with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as manifest_file:


### PR DESCRIPTION
## Description

Stacked on #361.

Adds `--recursive` so directory spec arguments expand to `.stone` files without requiring a bespoke `--spec-root` mode.

## **Checklist**

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [x] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [x] Do the tests pass?

Verification run directly with the CI lint/test steps:
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with flake8==5.0.4 --with pylint flake8 setup.py example stone test`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with flake8==5.0.4 --with pylint --with setuptools pylint --rcfile=.pylintrc setup.py example stone test`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with pytest --with mock pytest`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with enum34 --with mypy --with types-six ./mypy-run.sh`
