### PR TITLE
Make Stone easier to invoke locally

### DIFF
--- a/stone/__main__.py
+++ b/stone/__main__.py
@@ -1,0 +1,5 @@
+from stone.cli import main
+
+
+if __name__ == '__main__':
+    main()

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -11,6 +11,10 @@ import os
 import sys
 import traceback
 
+if __package__ in (None, ''):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    __package__ = 'stone'  # pylint: disable=redefined-builtin
+
 from .cli_helpers import parse_route_attr_filter
 from .compiler import (
     BackendException,


### PR DESCRIPTION
## Description

Stacked on #359.

Allows `stone/cli.py` to bootstrap its package path when run directly and adds `stone/__main__.py` for module invocation.

## **Checklist**

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Have you ran `tox`?
- [x] Do the tests pass?

Verification run directly with the CI lint/test steps:
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with flake8==5.0.4 --with pylint flake8 setup.py example stone test`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with flake8==5.0.4 --with pylint --with setuptools pylint --rcfile=.pylintrc setup.py example stone test`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with pytest --with mock pytest`
- `uv run --no-project --with-requirements requirements.txt --with-requirements test/requirements.txt --with enum34 --with mypy --with types-six ./mypy-run.sh`
