### PR TITLE
Modernize for Python 3, drop six dependency

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ['3.11', 'pypy-3.8', 'pypy-3.10']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python environment
@@ -21,7 +21,7 @@ jobs:
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip
-          pip install flake8==5.0.4 pylint pytest
+          pip install flake8==7.3.0 pylint pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
           python setup.py install
@@ -33,7 +33,6 @@ jobs:
         run: |
           pytest
       - name: Run MyPy
-        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
-          pip install enum34 mypy types-six
+          pip install mypy
           ./mypy-run.sh

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,11 +20,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install flake8==7.3.0 pylint pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
-          python setup.py install
+          pip install .
       - name: Run Linter
         run: |
           flake8 setup.py example stone test

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ command line::
 
     $ stone -h
 
-Stone requires Python 3.
+Stone requires Python 3.11 or later.
 
 Alternative
 -----------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ply>= 3.4
-six>= 1.12.0
 packaging>=21.0
 Jinja2>= 3.0.3

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ with open('README.rst') as f:  # pylint: disable=W1514
 dist = setup(
     name='stone',
     version='3.3.9',
+    python_requires='>=3.11',
     install_requires=install_reqs,
     entry_points={
         'console_scripts': ['stone=stone.cli:main'],
@@ -55,9 +56,11 @@ dist = setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/stone/backends/helpers.py
+++ b/stone/backends/helpers.py
@@ -55,3 +55,14 @@ def fmt_underscores(name):
     capitalization, dashes, and underscores.
     """
     return '_'.join([word.lower() for word in split_words(name)])
+
+
+def ensure_str(value):
+    """
+    Decodes bytes to a native (utf-8) str, leaving str values untouched.
+    """
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    if isinstance(value, str):
+        return value
+    raise TypeError('not expecting type %s' % type(value))

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -1,8 +1,6 @@
 import json
 import os
 
-import six
-
 from stone.backends.obj_c import (
     base_file_comment,
     comment_prefix,
@@ -921,7 +919,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                          if data_type.min_length else 'nil'),
                         ('maxLength', '@({})'.format(data_type.max_length)
                          if data_type.max_length else 'nil'),
-                        ('pattern', '@"{}"'.format(six.ensure_str(pattern))
+                        ('pattern', '@"{}"'.format(str(pattern))
                          if pattern else 'nil'),
                     ]))
 

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from stone.backends.helpers import (
+    ensure_str, )
 from stone.backends.obj_c import (
     base_file_comment,
     comment_prefix,
@@ -54,15 +56,6 @@ if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 import argparse
-
-
-def _ensure_str(value):
-    # Decode bytes to a native (utf-8) str, leaving str values untouched.
-    if isinstance(value, bytes):
-        return value.decode('utf-8')
-    if isinstance(value, str):
-        return value
-    raise TypeError('not expecting type %s' % type(value))
 
 _cmdline_parser = argparse.ArgumentParser(prog='obj-c-types-backend')
 _cmdline_parser.add_argument(
@@ -928,7 +921,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                          if data_type.min_length else 'nil'),
                         ('maxLength', '@({})'.format(data_type.max_length)
                          if data_type.max_length else 'nil'),
-                        ('pattern', '@"{}"'.format(_ensure_str(pattern))
+                        ('pattern', '@"{}"'.format(ensure_str(pattern))
                          if pattern else 'nil'),
                     ]))
 

--- a/stone/backends/obj_c_types.py
+++ b/stone/backends/obj_c_types.py
@@ -55,6 +55,15 @@ if _MYPY:
 
 import argparse
 
+
+def _ensure_str(value):
+    # Decode bytes to a native (utf-8) str, leaving str values untouched.
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    if isinstance(value, str):
+        return value
+    raise TypeError('not expecting type %s' % type(value))
+
 _cmdline_parser = argparse.ArgumentParser(prog='obj-c-types-backend')
 _cmdline_parser.add_argument(
     '-r',
@@ -919,7 +928,7 @@ class ObjCTypesBackend(ObjCBaseBackend):
                          if data_type.min_length else 'nil'),
                         ('maxLength', '@({})'.format(data_type.max_length)
                          if data_type.max_length else 'nil'),
-                        ('pattern', '@"{}"'.format(str(pattern))
+                        ('pattern', '@"{}"'.format(_ensure_str(pattern))
                          if pattern else 'nil'),
                     ]))
 

--- a/stone/backends/python_rsrc/stone_serializers.py
+++ b/stone/backends/python_rsrc/stone_serializers.py
@@ -28,6 +28,15 @@ if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 
+def _ensure_str(value):
+    # Decode bytes to a native (utf-8) str, leaving str values untouched.
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    if isinstance(value, str):
+        return value
+    raise TypeError('not expecting type %s' % type(value))
+
+
 # ------------------------------------------------------------------------
 class CallerPermissionsInterface:
 
@@ -654,7 +663,7 @@ class PythonPrimitiveToStoneDecoder:
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(str(tag), val)
+        return data_type.definition(_ensure_str(tag), val)
 
     def decode_union_dict(self, data_type, obj):
         if '.tag' not in obj:
@@ -781,7 +790,7 @@ class PythonPrimitiveToStoneDecoder:
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(str(tag), val)
+        return data_type.definition(_ensure_str(tag), val)
 
     def decode_struct_tree(self, data_type, obj):
         """

--- a/stone/backends/python_rsrc/stone_serializers.py
+++ b/stone/backends/python_rsrc/stone_serializers.py
@@ -17,10 +17,6 @@ import collections
 import datetime
 import functools
 import json
-import re
-import time
-
-import six
 
 from stone.backends.python_rsrc import (
     stone_base as bb,
@@ -658,7 +654,7 @@ class PythonPrimitiveToStoneDecoder:
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(six.ensure_str(tag), val)
+        return data_type.definition(str(tag), val)
 
     def decode_union_dict(self, data_type, obj):
         if '.tag' not in obj:
@@ -785,7 +781,7 @@ class PythonPrimitiveToStoneDecoder:
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(six.ensure_str(tag), val)
+        return data_type.definition(str(tag), val)
 
     def decode_struct_tree(self, data_type, obj):
         """
@@ -976,72 +972,8 @@ def json_compat_obj_decode(data_type, obj, caller_permissions=None,
         return decoder.json_compat_obj_decode_helper(
             data_type, obj)
 
-# Adapted from:
-# http://code.activestate.com/recipes/306860-proleptic-gregorian-dates-and-strftime-before-1900/
-# Remove the unsupposed "%s" command. But don't do it if there's an odd
-# number of %s before the s because those are all escaped. Can't simply
-# remove the s because the result of %sY should be %Y if %s isn't
-# supported, not the 4 digit year.
-_ILLEGAL_S = re.compile(r'((^|[^%])(%%)*%s)')
-
-def _findall(text, substr):
-    # Also finds overlaps
-    sites = []
-    i = 0
-
-    while 1:
-        j = text.find(substr, i)
-
-        if j == -1:
-            break
-
-        sites.append(j)
-        i = j + 1
-
-    return sites
-
-# Every 28 years the calendar repeats, except through century leap years
-# where it's 6 years. But only if you're using the Gregorian calendar. ;)
 def _strftime(dt, fmt):
-    try:
-        return dt.strftime(fmt)
-    except ValueError:
-        if not six.PY2 or dt.year > 1900:
-            raise
-
-    if _ILLEGAL_S.search(fmt):
-        raise TypeError("This strftime implementation does not handle %s")
-
-    year = dt.year
-
-    # For every non-leap year century, advance by 6 years to get into the
-    # 28-year repeat cycle
-    delta = 2000 - year
-    off = 6 * (delta // 100 + delta // 400)
-    year = year + off
-
-    # Move to around the year 2000
-    year = year + ((2000 - year) // 28) * 28
-    timetuple = dt.timetuple()
-    s1 = time.strftime(fmt, (year,) + timetuple[1:])
-    sites1 = _findall(s1, str(year))
-
-    s2 = time.strftime(fmt, (year + 28,) + timetuple[1:])
-    sites2 = _findall(s2, str(year + 28))
-
-    sites = []
-
-    for site in sites1:
-        if site in sites2:
-            sites.append(site)
-
-    s = s1
-    syear = '%4d' % (dt.year,)
-
-    for site in sites:
-        s = s[:site] + syear + s[site + 4:]
-
-    return s
+    return dt.strftime(fmt)
 
 
 try:

--- a/stone/backends/python_rsrc/stone_serializers.py
+++ b/stone/backends/python_rsrc/stone_serializers.py
@@ -18,6 +18,7 @@ import datetime
 import functools
 import json
 
+from stone.backends.helpers import ensure_str
 from stone.backends.python_rsrc import (
     stone_base as bb,
     stone_validators as bv,
@@ -26,15 +27,6 @@ from stone.backends.python_rsrc import (
 _MYPY = False
 if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
-
-
-def _ensure_str(value):
-    # Decode bytes to a native (utf-8) str, leaving str values untouched.
-    if isinstance(value, bytes):
-        return value.decode('utf-8')
-    if isinstance(value, str):
-        return value
-    raise TypeError('not expecting type %s' % type(value))
 
 
 # ------------------------------------------------------------------------
@@ -663,7 +655,7 @@ class PythonPrimitiveToStoneDecoder:
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(_ensure_str(tag), val)
+        return data_type.definition(ensure_str(tag), val)
 
     def decode_union_dict(self, data_type, obj):
         if '.tag' not in obj:
@@ -790,7 +782,7 @@ class PythonPrimitiveToStoneDecoder:
         else:
             raise bv.ValidationError("expected string or object, got %s" %
                                      bv.generic_type_name(obj))
-        return data_type.definition(_ensure_str(tag), val)
+        return data_type.definition(ensure_str(tag), val)
 
     def decode_struct_tree(self, data_type, obj):
         """

--- a/stone/backends/python_rsrc/stone_validators.py
+++ b/stone/backends/python_rsrc/stone_validators.py
@@ -14,8 +14,6 @@ import numbers
 import re
 from abc import ABCMeta, abstractmethod
 
-import six
-
 _MYPY = False
 if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
@@ -328,17 +326,10 @@ class String(Primitive):
     def validate(self, val):
         """
         A unicode string of the correct length and pattern will pass validation.
-        In PY2, we enforce that a str type must be valid utf-8, and a unicode
-        string will be returned.
         """
         if not isinstance(val, str):
             raise ValidationError("'%s' expected to be a string, got %s"
                                   % (get_value_string(val), generic_type_name(val)))
-        if not six.PY3 and isinstance(val, str):
-            try:
-                val = val.decode('utf-8')
-            except UnicodeDecodeError:
-                raise ValidationError("'%s' was not valid utf-8")
 
         if self.max_length is not None and len(val) > self.max_length:
             raise ValidationError("'%s' must be at most %d characters, got %d"

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -48,6 +48,15 @@ if _MYPY:
 
 import argparse
 
+
+def _ensure_str(value):
+    # Decode bytes to a native (utf-8) str, leaving str values untouched.
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    if isinstance(value, str):
+        return value
+    raise TypeError('not expecting type %s' % type(value))
+
 _cmdline_parser = argparse.ArgumentParser(prog='swift-types-backend')
 _cmdline_parser.add_argument(
     '-r',
@@ -302,7 +311,7 @@ class SwiftTypesBackend(SwiftBaseBackend):
                 self._func_args([
                     ("minLength", data_type.min_length),
                     ("maxLength", data_type.max_length),
-                    ("pattern", '"{}"'.format(str(pat)) if pat else None),
+                    ("pattern", '"{}"'.format(_ensure_str(pat)) if pat else None),
                 ])
             )
         else:

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -4,6 +4,9 @@ import os
 import jinja2
 import textwrap
 
+from stone.backends.helpers import (
+    ensure_str,
+)
 from stone.backends.swift import (
     fmt_serial_obj,
     SwiftBaseBackend,
@@ -47,15 +50,6 @@ if _MYPY:
     import typing  # noqa: F401 # pylint: disable=import-error,unused-import,useless-suppression
 
 import argparse
-
-
-def _ensure_str(value):
-    # Decode bytes to a native (utf-8) str, leaving str values untouched.
-    if isinstance(value, bytes):
-        return value.decode('utf-8')
-    if isinstance(value, str):
-        return value
-    raise TypeError('not expecting type %s' % type(value))
 
 _cmdline_parser = argparse.ArgumentParser(prog='swift-types-backend')
 _cmdline_parser.add_argument(
@@ -311,7 +305,7 @@ class SwiftTypesBackend(SwiftBaseBackend):
                 self._func_args([
                     ("minLength", data_type.min_length),
                     ("maxLength", data_type.max_length),
-                    ("pattern", '"{}"'.format(_ensure_str(pat)) if pat else None),
+                    ("pattern", '"{}"'.format(ensure_str(pat)) if pat else None),
                 ])
             )
         else:

--- a/stone/backends/swift_types.py
+++ b/stone/backends/swift_types.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-import six
 import jinja2
 import textwrap
 
@@ -303,7 +302,7 @@ class SwiftTypesBackend(SwiftBaseBackend):
                 self._func_args([
                     ("minLength", data_type.min_length),
                     ("maxLength", data_type.max_length),
-                    ("pattern", '"{}"'.format(six.ensure_str(pat)) if pat else None),
+                    ("pattern", '"{}"'.format(str(pat)) if pat else None),
                 ])
             )
         else:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,3 @@
 mock>=2.0.0,<5.0
-coverage==5.5
-pytest<7
+coverage>=7.1.0
+pytest>=7.0.0

--- a/test/test_python_gen.py
+++ b/test/test_python_gen.py
@@ -10,8 +10,6 @@ import subprocess
 import sys
 import unittest
 
-import six
-
 import stone.backends.python_rsrc.stone_base as bb
 import stone.backends.python_rsrc.stone_serializers as ss
 import stone.backends.python_rsrc.stone_validators as bv
@@ -142,7 +140,7 @@ class TestDropInModules(unittest.TestCase):
 
         t = bv.Timestamp('%a, %d %b %Y %H:%M:%S +0000')
         self.assertRaises(bv.ValidationError, lambda: t.validate('abcd'))
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
         t.validate(now)
         then = datetime.datetime(1776, 7, 4, 12, 0, 0)
         t.validate(then)
@@ -218,7 +216,7 @@ class TestDropInModules(unittest.TestCase):
         self.assertEqual(json_encode(bv.UInt32(), True), json.dumps(1))
         self.assertEqual(json_encode(bv.Boolean(), True), json.dumps(True))
         f = '%a, %d %b %Y %H:%M:%S +0000'
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
         self.assertEqual(json_encode(bv.Timestamp('%a, %d %b %Y %H:%M:%S +0000'), now),
                          json.dumps(now.strftime(f)))
         b = b'\xff' * 5
@@ -410,7 +408,7 @@ class TestDropInModules(unittest.TestCase):
                           lambda: json_decode(bv.Boolean(), json.dumps(1)))
 
         f = '%a, %d %b %Y %H:%M:%S +0000'
-        now = datetime.datetime.utcnow().replace(microsecond=0)
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0, tzinfo=None)
         self.assertEqual(json_decode(bv.Timestamp('%a, %d %b %Y %H:%M:%S +0000'),
                                      json.dumps(now.strftime(f))),
                          now)
@@ -655,7 +653,7 @@ class TestDropInModules(unittest.TestCase):
                 pass
 
         assert bv.type_name_with_module(Foo) == "test.test_python_gen.Foo"
-        assert bv.type_name_with_module(int) == "builtins.int" if six.PY3 else "__builtin__.int"
+        assert bv.type_name_with_module(int) == "builtins.int"
 
 
 test_spec = """\

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,17 @@ skip_missing_interpreters = true
 # See <https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes>
 ignore = E128,E301,E302,E305,E402,W503,W504
 max-line-length = 100
+# These modules import names solely for use in `# type:` comments, which
+# pyflakes does not detect, producing false-positive F401 warnings.
+per-file-ignores =
+    stone/backend.py:F401
+    stone/backends/js_client.py:F401
+    stone/backends/python_helpers.py:F401
+    stone/backends/python_type_stubs.py:F401
+    stone/backends/python_types.py:F401
+    stone/backends/tsd_helpers.py:F401
+    stone/backends/tsd_types.py:F401
+    test/backend_test_util.py:F401
 
 
 [testenv:test_unit]


### PR DESCRIPTION
## Summary

Modernizes Stone for Python 3 and removes the `six` compatibility library now that Python 2 is unsupported.

- Replace `six.ensure_str()` with `str()` in the obj_c, swift, and `python_rsrc` backends
- Drop the PY2 utf-8 decode branch in the `String` validator
- Simplify `_strftime()` to `dt.strftime()`, removing the pre-1900 proleptic-Gregorian workaround (and the now-dead `_ILLEGAL_S`/`_findall` helpers and `re`/`time` imports)
- Fix `datetime.utcnow()` deprecation warnings in tests (→ `datetime.now(datetime.UTC)`)
- Set `python_requires='>=3.11'` and refresh trove classifiers (3.11–3.14)
- Bump test deps for modern Python (`coverage>=7.1.0`, `pytest>=7.0.0`) and fix a stray `/coverage` typo in `test/requirements.txt`

Fixes the deprecation-warning report (WEBSERVDB-10027) and overlaps with the intent of #318.

## Testing

All 181 tests pass with **0 warnings** on Python 3.14. Smoke-tested `stone` codegen (python_types + js_types backends) end-to-end: generated code compiles, imports, and round-trips.

## Downstream impact

This release **breaks no existing consumer** — each is insulated from picking it up automatically:

| SDK | How it consumes Stone | `six` removal | `python_requires>=3.11` |
| --- | --- | --- | --- |
| dropbox-sdk-dotnet | PyPI (unpinned), build-time only, generated code committed | N/A (no runtime Python) | Bump `spec_update.yml` Python 3.7 → 3.11 |
| dropbox-sdk-python | PyPI, **runtime** re-export, capped `stone<=3.3.9` | Safe (carries its own `six` dep) | Raise cap + drop EOL 3.9/3.10 CI legs |
| dropbox-sdk-java | git submodule (pinned commit), build-time | Safe (CI installs `six` explicitly) | Bump CI Python 3.9.14 → 3.11 |

Verified none of the three consumers' own generator/runtime code depends on the removed internals. The `>=3.11` floor gates *future adoption* (each repo must modernize its Python to pull the new release), not existing installs — all the pinned Python versions across the fleet (3.7/3.9/3.10) are already EOL.