### PR TITLE
Update PyPI publish OIDC role to repository-wide role name

### DIFF
--- a/.github/workflows/pypiupload.yaml
+++ b/.github/workflows/pypiupload.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure AWS credentials (OIDC)
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-stone-branch-main
+        role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-stone-repo
         aws-region: us-west-2
     - name: Get PyPI token from AWS Secrets Manager
       id: get-secret


### PR DESCRIPTION
The stone-main OIDC role is being changed to repository_wide in the secrets Terraform, which renames it from oidc-github-dropbox-stone-branch-main to oidc-github-dropbox-stone-repo. The prior branch_only="main" trust condition never matched release-triggered runs (tag refs), causing "Not authorized to perform sts:AssumeRoleWithWebIdentity".

Point role-to-assume at the new role name.

<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [x] Code Change
- [x] Example/Test Code Change

**Validation**
- [x] Have you ran `tox`?
- [x] Do the tests pass?