### PR TITLE
Bump version to 3.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as f:  # pylint: disable=W1514
 
 dist = setup(
     name='stone',
-    version='3.4.0',
+    version='3.5.0',
     python_requires='>=3.11',
     install_requires=install_reqs,
     entry_points={


### PR DESCRIPTION
Bumps the version `3.4.0` → `3.5.0` to release the packaging fixes merged in #369:

- **#368** — replace the deprecated `License :: OSI Approved :: MIT License` classifier with the PEP 639 SPDX `license_expression = 'MIT'`, add `pyproject.toml` pinning `setuptools>=77`, and remove the dead `ez_setup.py` bootstrap.
- **#343** — `recursive-include test *.py` so the sdist ships a complete, runnable test package (`test/__init__.py` and `test/backend_test_util.py` were previously missing, breaking `pytest` from the PyPI source tarball).