### PR TITLE
Bump version to 3.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as f:  # pylint: disable=W1514
 
 dist = setup(
     name='stone',
-    version='3.4.0',
+    version='3.5.0',
     python_requires='>=3.11',
     install_requires=install_reqs,
     entry_points={


### PR DESCRIPTION
Step 2 of the release process: bump the `version` field in `setup.py` (`3.4.0` → `3.5.0`) in a separate commit to release the packaging fixes merged in #369:

- **#368** — PEP 639 SPDX `license_expression = 'MIT'` replacing the deprecated license classifier; `pyproject.toml` pinning `setuptools>=77`; removal of the dead `ez_setup.py` bootstrap.
- **#343** — `recursive-include test *.py` so the sdist ships a complete, runnable test package.

Once merged, the release is cut per the documented process: `sh scripts/update_version.sh 3.5.0` to tag `v3.5.0`, then create a GitHub Release from that tag, which triggers `pypiupload.yaml` to build and publish to PyPI.