### PR TITLE
Match generated abstract request() to transport signature

### DIFF
--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -140,7 +140,8 @@ class PythonClientBackend(CodeBackend):
                 self.emit()
                 self.emit('@abstractmethod')
                 self.emit(
-                    'def request(self, route, namespace, arg, arg_binary=None):')
+                    'def request(self, route, namespace, request_arg, '
+                    'request_binary, timeout=None):')
                 with self.indent():
                     self.emit('pass')
                 self.emit()

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -1,7 +1,11 @@
+import os
+import shutil
+import tempfile
 import textwrap
 
 from stone.backends.python_client import PythonClientBackend
 from stone.ir import (
+    Api,
     ApiNamespace,
     ApiRoute,
     Int32,
@@ -43,6 +47,44 @@ class TestGeneratedPythonClient(unittest.TestCase):
             args=['-w', auth_mode, '-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'])
         backend._generate_route_methods({ns})
         return backend.output_buffer_to_string()
+
+    def _generate_module(self, ns):
+        # type: (ApiNamespace) -> typing.Text
+
+        # Exercises the full generate() path (which writes to disk) and
+        # returns the contents of the generated module.
+        api = Api(version='0.1b1')
+        api.namespaces[ns.name] = ns
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            backend = PythonClientBackend(
+                target_folder_path=tmp_dir,
+                args=['-m', 'base', '-c', 'DropboxBase', '-t', 'dropbox'])
+            backend.generate(api)
+            with open(os.path.join(tmp_dir, 'base.py'), encoding='utf-8') as f:
+                return f.read()
+        finally:
+            shutil.rmtree(tmp_dir)
+
+    def test_abstract_request_signature(self):
+        # type: () -> None
+
+        # The generated abstract request() must match the concrete
+        # _DropboxTransport.request signature in dropbox-sdk-python so the
+        # two base classes are Liskov-compatible under mypy (see
+        # dropbox/dropbox-sdk-python#511).
+        route = ApiRoute('get_metadata', 1, None)
+        route.set_attributes(None, None, Void(), Void(), Void(), {})
+        ns = ApiNamespace('files')
+        ns.add_route(route)
+
+        result = self._generate_module(ns)
+
+        self.assertIn(
+            '@abstractmethod\n'
+            '    def request(self, route, namespace, request_arg, '
+            'request_binary, timeout=None):',
+            result)
 
     def test_route_with_version_number(self):
         # type: () -> None


### PR DESCRIPTION
## Summary

The `python_client` backend emitted an abstract `request()` with signature `(route, namespace, arg, arg_binary=None)`, which did not match the concrete `_DropboxTransport.request(route, namespace, request_arg, request_binary, timeout=None)` in `dropbox-sdk-python`. mypy flagged the two base classes as having incompatible `request()` definitions — see [dropbox/dropbox-sdk-python#511](https://github.com/dropbox/dropbox-sdk-python/issues/511).

This emits the matching signature so the generated base classes are Liskov-compatible with the transport.

## Backward compatibility

Fully backward compatible. Generated route methods only ever call `self.request(...)` with the first four arguments positionally, so renaming the parameters and adding the optional `timeout=None` changes nothing for existing callers. The abstract method has an empty body — only its signature matters for typing.

## Testing

- New `test_abstract_request_signature` asserts the generated abstract method matches the transport signature (exercises the full `generate()` path).
- Full test suite passes (182 tests); `flake8` clean.