### PR TITLE
Derive package version from git tags via setuptools-scm

### DIFF
--- a/.github/workflows/pypiupload.yaml
+++ b/.github/workflows/pypiupload.yaml
@@ -6,7 +6,12 @@ name: Publish to PyPi
 on:
   release:
     types: [created]
-  workflow_dispatch:  # Allow manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish (for example, v3.6.0)
+        required: true
+        type: string
 
 jobs:
   deploy:
@@ -20,6 +25,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.release.tag_name || inputs.tag }}
+        fetch-depth: 0
 
     - name: Configure AWS credentials (OIDC)
       uses: aws-actions/configure-aws-credentials@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,12 @@
 [build-system]
 # setuptools>=77 is required for the SPDX ``license`` expression used in
-# setup.py (see PEP 639).
-requires = ["setuptools>=77"]
+# setup.py (see PEP 639). setuptools-scm derives the version from the latest
+# git tag (e.g. ``v3.5.0`` -> ``3.5.0``), so releases only require tagging.
+requires = ["setuptools>=77", "setuptools-scm>=8,<9"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# Derive the distribution version from git tags. The leading ``v`` is stripped
+# by default (``v3.5.0`` -> ``3.5.0``); an untagged build gets a dev version
+# from the last tag plus commit distance.
+parentdir_prefix_version = "stone-"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as f:  # pylint: disable=W1514
 
 dist = setup(
     name='stone',
-    version='3.5.0',
+    # version is derived from git tags by setuptools-scm (see pyproject.toml).
     python_requires='>=3.11',
     install_requires=install_reqs,
     entry_points={


### PR DESCRIPTION
## Summary

Automate release versioning: the package version is now derived from the git tag by `setuptools-scm` instead of a hardcoded string in `setup.py`. Tagging `vX.Y.Z` becomes the single source of truth, so the manual "bump version" commit (e.g. #371) is no longer needed.

## Changes

- **`setup.py`** — removed the hardcoded `version='3.5.0'`; the version now comes from `setuptools-scm`.
- **`pyproject.toml`** — added `setuptools-scm>=8,<9` to build requires and a `[tool.setuptools_scm]` section.
  - Pinned `<9` because the current 10.x fails the wheel build with `MetadataWorkdir has no attribute project_root`.
  - `parentdir_prefix_version = "stone-"` recovers the version from the sdist directory name when neither git nor `PKG-INFO` is available.
- **`.github/workflows/pypiupload.yaml`** — the publish job now checks out the release tag with full history (`fetch-depth: 0`, `ref: release tag`). This is required: the default shallow, tagless checkout would make `setuptools-scm` build a mislabeled artifact. `workflow_dispatch` takes an explicit `tag` input for manual re-runs.

## New release flow

1. `scripts/update_version.sh 3.6.0` (unchanged — tags `v3.6.0` and pushes).
2. Create the GitHub Release for the tag.
3. `pypiupload.yaml` checks out the tag, builds, and publishes `stone==3.6.0`.

The git tag and the published version can no longer drift apart.