### PR TITLE
Add --version flag to the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.xml
 /.tox/
 /build/
 /dist/
+/stone/_version.py
 __pycache__/
 .DS_Store
 parser.out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 # setuptools>=77 is required for the SPDX ``license`` expression used in
 # setup.py (see PEP 639). setuptools-scm derives the version from the latest
-# git tag (e.g. ``v3.5.0`` -> ``3.5.0``), so releases only require tagging.
+# git tag (e.g. ``v3.5.0`` -> ``3.5.0``), so releases only require tagging,
+# and writes it to stone/_version.py for runtime access.
 requires = ["setuptools>=77", "setuptools-scm>=8,<9"]
 build-backend = "setuptools.build_meta"
 
@@ -10,3 +11,4 @@ build-backend = "setuptools.build_meta"
 # by default (``v3.5.0`` -> ``3.5.0``); an untagged build gets a dev version
 # from the last tag plus commit distance.
 parentdir_prefix_version = "stone-"
+version_file = "stone/_version.py"

--- a/stone/__init__.py
+++ b/stone/__init__.py
@@ -1,0 +1,7 @@
+try:
+    from ._version import __version__
+except ModuleNotFoundError:
+    # A source tree that has not been built or installed yet.
+    __version__ = '0.0.0.dev0'
+
+__all__ = ('__version__',)

--- a/stone/cli.py
+++ b/stone/cli.py
@@ -15,6 +15,7 @@ if __package__ in (None, ''):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     __package__ = 'stone'  # pylint: disable=redefined-builtin
 
+from . import __version__
 from .cli_helpers import parse_route_attr_filter
 from .compiler import (
     BackendException,
@@ -54,6 +55,12 @@ _cmdline_description = (
     'example.spec -- -h".'
 )
 _cmdline_parser = argparse.ArgumentParser(description=_cmdline_description)
+_cmdline_parser.add_argument(
+    '--version',
+    action='version',
+    version='%(prog)s ' + __version__,
+    help="Show the Stone version and exit.",
+)
 _cmdline_parser.add_argument(
     '-v',
     '--verbose',

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 
 
+import contextlib
+import io
 import json
 import os
 import tempfile
 import unittest
 
+from stone import __version__
 from stone.cli import (
     _actual_outputs,
+    _cmdline_parser,
     _load_expected_output_manifest,
     _recursive_stone_specs,
     _validate_expected_output_manifest,
@@ -179,6 +183,15 @@ class TestCLI(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             _validate_expected_output_manifest(['a.py'], ['b.py'])
+
+    def test_version_flag(self):
+        # --version prints the version and exits 0, without requiring the
+        # otherwise-mandatory positional arguments.
+        out = io.StringIO()
+        with self.assertRaises(SystemExit) as cm, contextlib.redirect_stdout(out):
+            _cmdline_parser.parse_args(['--version'])
+        self.assertEqual(cm.exception.code, 0)
+        self.assertIn(__version__, out.getvalue())
 
 
 if __name__ == '__main__':

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+
+import importlib.util
+import sys
+import types
+import unittest
+from unittest import mock
+
+import stone
+
+
+class TestVersion(unittest.TestCase):
+
+    def test_generated_version_is_used_in_source_checkout(self):
+        generated_version = types.ModuleType('stone._version')
+        generated_version.__version__ = '9.8.7'
+
+        spec = importlib.util.spec_from_file_location(
+            'stone._version_test', stone.__file__)
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = 'stone'
+        with mock.patch.dict(sys.modules, {'stone._version': generated_version}):
+            spec.loader.exec_module(module)
+
+        self.assertEqual(module.__version__, '9.8.7')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a `stone --version` flag and exposes the package version programmatically as `stone.__version__`. Useful for bug reports and scripting.

```
$ stone --version
stone 3.5.1
```

## Changes

- **`pyproject.toml`** — configures setuptools-scm to generate `stone/_version.py` from the release tag.
- **`stone/__init__.py`** — exposes the generated version, with a `0.0.0.dev0` fallback for an unbuilt source tree.
- **`stone/cli.py`** — adds a long-form `--version` argument; `-v` remains `--verbose`.
- **Tests** — verifies `--version` exits successfully and that a generated version is honored in a source checkout.

## Testing

- Full test suite: 184 passed.
- flake8: clean.
- pylint: 10.00/10.
- Wheel build includes the generated version module and reports the derived package version.
