### PR TITLE
Fix Python documentation generation

### DIFF
--- a/stone/backends/python_client.py
+++ b/stone/backends/python_client.py
@@ -425,25 +425,19 @@ class PythonClientBackend(CodeBackend):
             if is_struct_type(arg_data_type):
                 for field in fields:
                     if field.doc:
-                        if is_user_defined_type(field.data_type):
-                            field_doc = ':param {}: {}'.format(
-                                field.name, self.process_doc(field.doc, self._docf))
-                        else:
-                            field_doc = ':param {} {}: {}'.format(
-                                self._format_type_in_doc(namespace, field.data_type),
-                                field.name,
-                                self.process_doc(field.doc, self._docf),
-                            )
+                        field_doc = ':param {}: {}'.format(
+                            field.name, self.process_doc(field.doc, self._docf))
                         self.emit_wrapped_text(
                             field_doc, subsequent_prefix='    ')
-                        if is_user_defined_type(field.data_type):
-                            # It's clearer to declare the type of a composite on
-                            # a separate line since it references a class in
-                            # another module
-                            self.emit(':type {}: {}'.format(
-                                field.name,
-                                self._format_type_in_doc(namespace, field.data_type),
-                            ))
+                        # Keeping the type out of the ``:param`` field name is
+                        # required for types that contain Sphinx roles. For
+                        # example, ``Nullable[:class:`package.Type`]`` would
+                        # otherwise terminate the field name early and produce
+                        # malformed reStructuredText.
+                        self.emit(':type {}: {}'.format(
+                            field.name,
+                            self._format_type_in_doc(namespace, field.data_type),
+                        ))
                     else:
                         # If the field has no docstring, then just document its
                         # type.
@@ -451,7 +445,10 @@ class PythonClientBackend(CodeBackend):
                             field.name,
                             self._format_type_in_doc(namespace, field.data_type),
                         )
-                        self.emit_wrapped_text(field_doc)
+                        # A Sphinx field marker must remain on one physical
+                        # line. If its value wraps without indentation,
+                        # docutils interprets the continuation as a new block.
+                        self.emit(field_doc)
 
             elif is_union_type(arg_data_type):
                 if arg_data_type.doc:
@@ -548,7 +545,10 @@ class PythonClientBackend(CodeBackend):
             return 'None'
         elif is_user_defined_type(data_type):
             return ':class:`{}.{}.{}`'.format(
-                self.args.types_package, namespace.name, fmt_type(data_type))
+                self.args.types_package,
+                fmt_namespace(data_type.namespace.name),
+                fmt_type(data_type),
+            )
         elif is_nullable_type(data_type):
             return 'Nullable[{}]'.format(
                 self._format_type_in_doc(namespace, data_type.data_type),

--- a/stone/backends/python_types.py
+++ b/stone/backends/python_types.py
@@ -46,7 +46,6 @@ from stone.backends.python_helpers import (
     fmt_class,
     fmt_func,
     fmt_namespace,
-    fmt_namespaced_var,
     fmt_obj,
     fmt_var,
     generate_imports_for_referenced_namespaces,
@@ -342,10 +341,14 @@ class PythonTypesBackend(CodeBackend):
                 for field in data_type.fields:
                     if not field.doc:
                         continue
-                    self.emit_wrapped_text(':ivar {}: {}'.format(
-                        fmt_namespaced_var(ns.name, data_type.name, field.name),
-                        self.process_doc(field.doc, self._docf)),
-                        subsequent_prefix='    ')
+                    formatted_var = '{}.{}'.format(
+                        fmt_class(data_type.name), fmt_var(field.name))
+                    # Keep the complete field marker on one line. Wrapping a
+                    # long ``:ivar Class.field:`` marker before its closing
+                    # colon produces invalid reStructuredText.
+                    self.emit(':ivar {}:'.format(formatted_var))
+                    self.emit_wrapped_text(
+                        self.process_doc(field.doc, self._docf), prefix='    ')
                 self.emit('"""')
             self.emit()
 
@@ -801,24 +804,16 @@ class PythonTypesBackend(CodeBackend):
             for field in data_type.fields:
                 if not field.doc:
                     continue
-                if is_void_type(field.data_type):
-                    ivar_doc = ':ivar {}: {}'.format(
-                        fmt_namespaced_var(ns.name, data_type.name, field.name),
-                        self.process_doc(field.doc, self._docf))
-                elif is_user_defined_type(field.data_type):
-                    if data_type.namespace.name != ns.name:
-                        formatted_var = fmt_namespaced_var(ns.name, data_type.name, field.name)
-                    else:
-                        formatted_var = '{}.{}'.format(data_type.name, fmt_var(field.name))
-                    ivar_doc = ':ivar {} {}: {}'.format(
-                        fmt_class(field.data_type.name),
+                formatted_var = '{}.{}'.format(
+                    fmt_class(data_type.name), fmt_var(field.name))
+                self.emit(':ivar {}:'.format(formatted_var))
+                self.emit_wrapped_text(
+                    self.process_doc(field.doc, self._docf), prefix='    ')
+                if not is_void_type(field.data_type):
+                    self.emit(':vartype {}: {}'.format(
                         formatted_var,
-                        self.process_doc(field.doc, self._docf))
-                else:
-                    ivar_doc = ':ivar {} {}: {}'.format(
                         self._python_type_mapping(ns, field.data_type),
-                        fmt_namespaced_var(ns.name, data_type.name, field.name), field.doc)
-                self.emit_wrapped_text(ivar_doc, subsequent_prefix='    ')
+                    ))
             self.emit('"""')
             self.emit()
 

--- a/test/test_python_client.py
+++ b/test/test_python_client.py
@@ -263,6 +263,57 @@ class TestGeneratedPythonClient(unittest.TestCase):
         self.assertEqual(backend._format_type_in_doc(ns, Map(String(), Int32())),
                          'Map[str, int]')
 
+    def test_route_argument_doc_uses_foreign_type_namespace(self):
+        team_common = ApiNamespace('team_common')
+        time_range = Struct('TimeRange', team_common, None)
+        time_range.set_attributes(None, [])
+
+        team_log = ApiNamespace('team_log')
+        args = Struct('GetTeamEventsArg', team_log, None)
+        args.set_attributes(None, [
+            StructField(
+                'time',
+                Nullable(time_range),
+                'Filter by time range.',
+                None,
+            ),
+            StructField(
+                'revoke_linked_app',
+                List(time_range),
+                None,
+                None,
+            ),
+        ])
+        route = ApiRoute('get_events', 1, None)
+        route.set_attributes(None, None, args, Void(), Void(), {})
+        team_log.add_route(route)
+
+        result = self._evaluate_namespace(team_log)
+
+        self.assertIn(
+            ':param time: Filter by time range.\n'
+            '    :type time: Nullable[:class:`dropbox.team_common.TimeRange`]',
+            result,
+        )
+        self.assertNotIn(':param Nullable[:class:', result)
+        self.assertIn(
+            ':type revoke_linked_app: '
+            'List[:class:`dropbox.team_common.TimeRange`]',
+            result,
+        )
+
+        async_ns = ApiNamespace('async')
+        poll_error = Struct('PollError', async_ns, None)
+        poll_error.set_attributes(None, [])
+        backend = PythonClientBackend(
+            target_folder_path='output',
+            args=['-m', 'files', '-c', 'DropboxBase', '-t', 'dropbox'],
+        )
+        self.assertEqual(
+            backend._format_type_in_doc(team_log, poll_error),
+            ':class:`dropbox.async_.PollError`',
+        )
+
     def test_route_with_attributes_in_docstring(self):
         # type: () -> None
 

--- a/test/test_python_types.py
+++ b/test/test_python_types.py
@@ -9,8 +9,11 @@ from stone.ir import (
     ApiRoute,
     CustomAnnotation,
     Int32,
+    String,
     Struct,
     StructField,
+    Union,
+    UnionField,
     Void,
 )
 
@@ -52,6 +55,12 @@ class TestGeneratedPythonTypes(unittest.TestCase):
         # type: (ApiNamespace, Struct) -> typing.Text
         backend = self._mock_backend()
         backend._generate_struct_class(ns, struct)
+        return backend.output_buffer_to_string()
+
+    def _evaluate_union(self, ns, union):
+        # type: (ApiNamespace, Union) -> typing.Text
+        backend = self._mock_backend()
+        backend._generate_union_class(ns, union)
         return backend.output_buffer_to_string()
 
     def _evaluate_annotation_type(self, ns, annotation_type):
@@ -273,5 +282,30 @@ class TestGeneratedPythonTypes(unittest.TestCase):
 
         ''')
         self.assertEqual(result, expected)
+
+    def test_union_docs_use_valid_sphinx_fields_and_convert_refs(self):
+        ns = ApiNamespace('team_log')
+        union = Union('EventType', ns, None, closed=True)
+        union.set_attributes(None, [
+            UnionField(
+                'team_folder_space_limits_change_notification_target',
+                String(),
+                'See :field:`EventType.other`.',
+                None,
+            ),
+        ])
+
+        result = self._evaluate_union(ns, union)
+
+        field_name = (
+            'EventType.team_folder_space_limits_change_notification_target'
+        )
+        self.assertIn(
+            ':ivar {name}:\n'
+            '        See ``EventType.other``.\n'
+            '    :vartype {name}: str'.format(name=field_name),
+            result,
+        )
+        self.assertNotIn(':field:', result)
 
     # TODO: add more unit tests for client code generation


### PR DESCRIPTION
## Summary

- keep generated Sphinx field markers intact by separating parameter/type and instance-variable/type fields
- resolve generated class references using the type's declaring namespace, including reserved Python module names such as `async_`
- convert Stone documentation tags consistently for union fields
- add regressions for cross-namespace types and long Sphinx fields

## Root cause

The Python backends embedded complex type roles inside `:param` field names and wrapped long `:ivar` markers before their closing colon. Docutils parsed those as malformed field and definition lists. The client backend also formatted foreign types with the route namespace instead of the type's declaring namespace, producing references such as `dropbox.team_log.TimeRange` and `dropbox.files.PollError`.

This affects [dropbox/dropbox-sdk-python#359](https://github.com/dropbox/dropbox-sdk-python/issues/359), [dropbox/dropbox-sdk-python#111](https://github.com/dropbox/dropbox-sdk-python/issues/111), and part of [dropbox/dropbox-sdk-python#516](https://github.com/dropbox/dropbox-sdk-python/issues/516).

## Impact

Generated Python API documentation uses valid reStructuredText and points to the correct modules. Runtime serialization and client behavior are unchanged.

Using this branch to regenerate the current Dropbox Python SDK reduced both HTML and man-page Sphinx warnings from 398 to 9. The remaining warnings come from handwritten SDK documentation or specification text, not Stone-generated field formatting.

## Validation

- `pytest -q` — 186 passed
- `flake8 setup.py example stone test`
- `pylint --rcfile=.pylintrc setup.py example stone test` — 10.00/10
- `./mypy-run.sh` — no issues in 59 files
- regenerated the current Dropbox Python SDK and built HTML and man documentation
